### PR TITLE
#8: Employee type ID name instead of ID in the preview

### DIFF
--- a/src/services/mappingService.ts
+++ b/src/services/mappingService.ts
@@ -1364,8 +1364,12 @@ export class MappingService {
       // Set the ID if we found a match - ensure it's always a number
       if (typeResult.ids.length > 0) {
         const resolvedId = typeResult.ids[0];
-        // Ensure employeeTypeId is always a number, not a string
-        converted.employeeTypeId = typeof resolvedId === 'string' ? parseInt(resolvedId, 10) : resolvedId;
+        const numericId = typeof resolvedId === 'string' ? parseInt(resolvedId, 10) : resolvedId;
+        // Store numeric ID internally for API payload (same pattern as departments/employeeGroups)
+        (converted as any).__employeeTypeId = numericId;
+        // Store human-readable name for UI display
+        const typeName = this.employeeTypesById.get(numericId);
+        converted.employeeTypeId = typeName || numericId;
       }
     }
 
@@ -2243,7 +2247,7 @@ export class MappingService {
     // Define internal fields that should be excluded from the API payload
     const internalFields = new Set([
       'rowIndex', 'originalData', '__internal_id', '_id', '_bulkCorrected',
-      '__departmentsIds', '__employeeGroupsIds', // Internal ID fields for API payload
+      '__departmentsIds', '__employeeGroupsIds', '__employeeTypeId', // Internal ID fields for API payload
       '__employeeGroupPayrates', 'wageValidFrom', // Payrate fields (handled separately after employee creation)
       '__supervisorAssignment', 'supervisorId', // Supervisor assignment (must be PUT after employee creation, not POST)
       '__fixedSalaryAssignment', 'salaryPeriod', 'salaryHours', 'salaryAmount', // Fixed salary (PUT after employee creation)
@@ -2300,6 +2304,10 @@ export class MappingService {
     }
     if (converted.__employeeGroupsIds && Array.isArray(converted.__employeeGroupsIds) && converted.__employeeGroupsIds.length > 0) {
       cleanPayload.employeeGroups = converted.__employeeGroupsIds;
+    }
+    // Special handling: Use internal numeric ID for employeeTypeId (display field stores name)
+    if ((converted as any).__employeeTypeId != null) {
+      cleanPayload.employeeTypeId = (converted as any).__employeeTypeId;
     }
 
     // Convert primaryDepartmentId from name to ID if it's a string


### PR DESCRIPTION
## Summary
Implemented issue #8: Employee type ID now displays as human-readable name instead of numeric ID in the preview.

**Changes in `src/services/mappingService.ts`:**

1. **`validateAndConvert()` (~line 1364)**: After resolving the employee type ID, now stores the numeric ID in an internal `__employeeTypeId` field and sets `employeeTypeId` to the human-readable name from `employeeTypesById` map (falling back to numeric ID if name not found). This follows the same pattern used for departments (`__departmentsIds`) and employee groups (`__employeeGroupsIds`).

2. **`createApiPayload()` (~line 2247)**: Added `__employeeTypeId` to the internal fields exclusion set so it's stripped from the generic field iteration.

3. **`createApiPayload()` (~line 2308)**: Added special handling to use `__employeeTypeId` numeric value for the API payload's `employeeTypeId` field, ensuring the API receives the correct numeric ID while the UI displays the name.

**What this achieves:**
- Preview table (FinalPreviewStep) shows employee type name (e.g., "Full-time") instead of numeric ID — the `__employeeTypeId` field is automatically excluded from display by the existing `!key.startsWith('__')` filter
- DataCorrectionStep search now filters by employee type name (better UX)
- API payload JSON preview still shows the numeric ID (via `createApiPayload`)
- No regression on department/employee group name resolution — same pattern used
- Re-validation works because `resolveEmployeeType()` already handles both name strings and numeric IDs

## Issues
Closes #8

Workbench session: 5a36a3eb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved employee type data handling to display human-readable names while maintaining proper internal ID management for API submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->