### PR TITLE
#21: Fix type safety for employeeTypeId in detectCommonErrors and

### DIFF
--- a/src/services/mappingService.ts
+++ b/src/services/mappingService.ts
@@ -860,7 +860,7 @@ export class MappingService {
           affectedRows++;
           totalErrors += result.errors.length;
 
-          const name = employee.employeeTypeId.trim();
+          const name = employee.employeeTypeId.toString().trim();
           const normalizedName = this.normalizeName(name);
 
           if (!this.employeeTypesByName.has(normalizedName) && !this.employeeTypesById.has(parseInt(name))) {
@@ -1369,7 +1369,7 @@ export class MappingService {
         (converted as any).__employeeTypeId = numericId;
         // Store human-readable name for UI display
         const typeName = this.employeeTypesById.get(numericId);
-        converted.employeeTypeId = typeName || numericId;
+        converted.employeeTypeId = typeName || String(numericId);
       }
     }
 


### PR DESCRIPTION
## Summary
Fixed two type safety issues with `employeeTypeId` in `src/services/mappingService.ts`:

1. **`detectCommonErrors()` (line 863):** Changed `employee.employeeTypeId.trim()` to `employee.employeeTypeId.toString().trim()` so numeric values from Excel don't crash on `.trim()`.

2. **`validateAndConvert()` (line 1372):** Changed `typeName || numericId` to `typeName || String(numericId)` so `converted.employeeTypeId` is always a string, preventing inconsistent typing downstream.

## Issues
Closes #21

Workbench session: 9adc0cfd