### PR TITLE
#23: Filter CellPhoneCountryPrefix from field definitions

### DIFF
--- a/src/services/mappingService.ts
+++ b/src/services/mappingService.ts
@@ -1646,6 +1646,7 @@ export class MappingService {
     // Fields to exclude from templates because they are auto-populated or deprecated
     const excludedFields = [
       'phone', 'phoneCountryCode', 'primaryDepartmentId', // phone/phoneCountryCode fields removed (only cellPhone/cellPhoneCountryCode supported), primaryDepartmentId is set via "xx" in department columns
+      'cellPhoneCountryPrefix', // unsupported for bulk upload
       'contractRulesRuleId', // internal reference, not user-settable
       'countryId',           // internal ID, not useful for bulk import
       'description',         // not a standard employee field for creation
@@ -2800,6 +2801,7 @@ export class ValidationService {
     // primaryDepartmentId is set via "xx" marker in department columns, not direct mapping
     const excludedFields = [
       'phone', 'phoneCountryCode', 'primaryDepartmentId',
+      'cellPhoneCountryPrefix', // unsupported for bulk upload
       'contractRulesRuleId', // internal reference, not user-settable
       'countryId',           // internal ID, not useful for bulk import
       'description',         // not a standard employee field for creation


### PR DESCRIPTION
## Summary
Added `cellPhoneCountryPrefix` to both `excludedFields` arrays in `src/services/mappingService.ts`:
1. In `generatePortalTemplate()` (~line 1649) — prevents the field from appearing in Excel templates
2. In `getAllAvailableFields()` (~line 2804) — prevents the field from appearing in the mapping UI

This matches the same pattern used for issue #7 and follows the existing convention for excluding unsupported fields from bulk upload.

## Issues
Closes #23

Workbench session: 9d73682b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated bulk import field exclusion to prevent an internal phone-related field from appearing in import templates and field mapping options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->