### PR TITLE
Resolve Excel dates by source cell type to stop spurious ambiguity prompts

### DIFF
--- a/src/components/mapping/MappingStep.tsx
+++ b/src/components/mapping/MappingStep.tsx
@@ -14,6 +14,7 @@ import { Button } from '../ui/Button';
 import { FieldSelectionModal } from '../ui/FieldSelectionModal';
 import { AUTO_MAPPING_RULES } from '../../constants/autoMappingRules';
 import { ValidationService, FieldDefinitionValidator } from '../../services/mappingService';
+import { DateParser } from '../../utils/dateParser';
 import type { Employee, ColumnMapping, ExcelColumnMapping, ParsedExcelData } from '../../types/planday';
 
 interface MappingStepProps {
@@ -47,7 +48,7 @@ interface PlandayField {
 const MappingStep: React.FC<MappingStepProps> = ({
   employees,
   headers,
-  // excelData, // Not currently used - reserved for future features
+  excelData,
   initialColumnMappings,
   savedMappings,
   savedCustomValues,
@@ -336,6 +337,14 @@ const MappingStep: React.FC<MappingStepProps> = ({
    * Apply column mappings to create Employee objects
    */
   const applyColumnMappings = (rawRows: any[][], mappings: ColumnMapping): Employee[] => {
+    // Date fields whose source column held raw serial numbers ("General"-formatted
+    // dates) need serial → ISO conversion up front, since they never reach the
+    // string-based date parser otherwise. Real date cells already arrive as ISO;
+    // text columns are left untouched for the ambiguity flow. (Issue #25)
+    const dateFields = new Set(ValidationService.getAllDateFields());
+    const columnExcelTypes = excelData?.columnExcelTypes;
+    const date1904 = excelData?.date1904 ?? false;
+
     return rawRows.map((row, index) => {
       const employee: Partial<Employee> = {
         rowIndex: index + 1
@@ -350,7 +359,19 @@ const MappingStep: React.FC<MappingStepProps> = ({
       // Map each field from Excel columns (skip ignored columns)
       for (const [columnName, fieldName] of Object.entries(mappings)) {
         if (fieldName && fieldName !== '__IGNORE__' && rowObject[columnName] !== undefined) {
-          employee[fieldName as keyof Employee] = rowObject[columnName];
+          let value = rowObject[columnName];
+
+          if (dateFields.has(fieldName) && columnExcelTypes?.[columnName] === 'numeric') {
+            const serial = Number(String(value).trim());
+            // Only treat plausible Excel serials as dates; larger integers (e.g.
+            // an 8-digit YYYYMMDD typed as a number) fall through to normal parsing.
+            if (Number.isInteger(serial) && serial >= 1 && serial <= 2958465) {
+              const iso = DateParser.excelSerialToISO(serial, date1904);
+              if (iso) value = iso;
+            }
+          }
+
+          employee[fieldName as keyof Employee] = value;
         }
       }
 

--- a/src/components/validation/DateFormatSelectionStep.tsx
+++ b/src/components/validation/DateFormatSelectionStep.tsx
@@ -27,15 +27,15 @@ function detectFormatOptions(samples: string[]): { option1: FormatOption; option
       option1: {
         format: 'MM/DD/YYYY',
         description: 'US format - Month/Day/Year',
-        example1: '01/02/1984 → 1984-01-02 (January 2, 1984)',
-        example2: '03/15/1984 → 1984-03-15 (March 15, 1984)',
+        example1: '01/02/1984 → January 2, 1984',
+        example2: '03/15/1984 → March 15, 1984',
         mapsToPlandayFormat: 'MM/DD/YYYY'
       },
       option2: {
         format: 'DD/MM/YYYY',
         description: 'European format - Day/Month/Year',
-        example1: '01/02/1984 → 1984-02-01 (February 1, 1984)',
-        example2: '15/03/1984 → 1984-03-15 (March 15, 1984)',
+        example1: '01/02/1984 → February 1, 1984',
+        example2: '15/03/1984 → March 15, 1984',
         mapsToPlandayFormat: 'DD/MM/YYYY'
       }
     };
@@ -55,15 +55,15 @@ function detectFormatOptions(samples: string[]): { option1: FormatOption; option
         option1: {
           format: 'YYYY/MM/DD',
           description: 'Year/Month/Day format',
-          example1: `${sample} → ${year}-${part1}-${part2} (${getMonthName(part1)} ${parseInt(part2)}, ${year})`,
-          example2: '1984/03/15 → 1984-03-15 (March 15, 1984)',
+          example1: `${sample} → ${getMonthName(part1)} ${parseInt(part2)}, ${year}`,
+          example2: '1984/03/15 → March 15, 1984',
           mapsToPlandayFormat: 'MM/DD/YYYY'
         },
         option2: {
           format: 'YYYY/DD/MM',
           description: 'Year/Day/Month format',
-          example1: `${sample} → ${year}-${part2}-${part1} (${getMonthName(part2)} ${parseInt(part1)}, ${year})`,
-          example2: '1984/15/03 → 1984-03-15 (March 15, 1984)',
+          example1: `${sample} → ${getMonthName(part2)} ${parseInt(part1)}, ${year}`,
+          example2: '1984/15/03 → March 15, 1984',
           mapsToPlandayFormat: 'DD/MM/YYYY'
         }
       };
@@ -77,15 +77,15 @@ function detectFormatOptions(samples: string[]): { option1: FormatOption; option
         option1: {
           format: 'MM/DD/YYYY',
           description: 'US format - Month/Day/Year',
-          example1: `${sample} → ${year}-${part1}-${part2} (${getMonthName(part1)} ${parseInt(part2)}, ${year})`,
-          example2: '03/15/1984 → 1984-03-15 (March 15, 1984)',
+          example1: `${sample} → ${getMonthName(part1)} ${parseInt(part2)}, ${year}`,
+          example2: '03/15/1984 → March 15, 1984',
           mapsToPlandayFormat: 'MM/DD/YYYY'
         },
         option2: {
           format: 'DD/MM/YYYY',
           description: 'European format - Day/Month/Year',
-          example1: `${sample} → ${year}-${part2}-${part1} (${getMonthName(part2)} ${parseInt(part1)}, ${year})`,
-          example2: '15/03/1984 → 1984-03-15 (March 15, 1984)',
+          example1: `${sample} → ${getMonthName(part2)} ${parseInt(part1)}, ${year}`,
+          example2: '15/03/1984 → March 15, 1984',
           mapsToPlandayFormat: 'DD/MM/YYYY'
         }
       };
@@ -104,15 +104,15 @@ function detectFormatOptions(samples: string[]): { option1: FormatOption; option
         option1: {
           format: 'YYYY.MM.DD',
           description: 'Year.Month.Day format',
-          example1: `${sample} → ${year}-${part1}-${part2} (${getMonthName(part1)} ${parseInt(part2)}, ${year})`,
-          example2: '1984.03.15 → 1984-03-15 (March 15, 1984)',
+          example1: `${sample} → ${getMonthName(part1)} ${parseInt(part2)}, ${year}`,
+          example2: '1984.03.15 → March 15, 1984',
           mapsToPlandayFormat: 'MM/DD/YYYY'
         },
         option2: {
           format: 'YYYY.DD.MM',
           description: 'Year.Day.Month format',
-          example1: `${sample} → ${year}-${part2}-${part1} (${getMonthName(part2)} ${parseInt(part1)}, ${year})`,
-          example2: '1984.15.03 → 1984-03-15 (March 15, 1984)',
+          example1: `${sample} → ${getMonthName(part2)} ${parseInt(part1)}, ${year}`,
+          example2: '1984.15.03 → March 15, 1984',
           mapsToPlandayFormat: 'DD/MM/YYYY'
         }
       };
@@ -126,15 +126,15 @@ function detectFormatOptions(samples: string[]): { option1: FormatOption; option
         option1: {
           format: 'MM.DD.YYYY',
           description: 'Month.Day.Year format',
-          example1: `${sample} → ${year}-${part1}-${part2} (${getMonthName(part1)} ${parseInt(part2)}, ${year})`,
-          example2: '03.15.1984 → 1984-03-15 (March 15, 1984)',
+          example1: `${sample} → ${getMonthName(part1)} ${parseInt(part2)}, ${year}`,
+          example2: '03.15.1984 → March 15, 1984',
           mapsToPlandayFormat: 'MM/DD/YYYY'
         },
         option2: {
           format: 'DD.MM.YYYY',
           description: 'Day.Month.Year format',
-          example1: `${sample} → ${year}-${part2}-${part1} (${getMonthName(part2)} ${parseInt(part1)}, ${year})`,
-          example2: '15.03.1984 → 1984-03-15 (March 15, 1984)',
+          example1: `${sample} → ${getMonthName(part2)} ${parseInt(part1)}, ${year}`,
+          example2: '15.03.1984 → March 15, 1984',
           mapsToPlandayFormat: 'DD/MM/YYYY'
         }
       };
@@ -153,15 +153,15 @@ function detectFormatOptions(samples: string[]): { option1: FormatOption; option
         option1: {
           format: 'YYYY-MM-DD',
           description: 'Year-Month-Day format',
-          example1: `${sample} → ${year}-${part1}-${part2} (${getMonthName(part1)} ${parseInt(part2)}, ${year})`,
-          example2: '1984-03-15 → 1984-03-15 (March 15, 1984)',
+          example1: `${sample} → ${getMonthName(part1)} ${parseInt(part2)}, ${year}`,
+          example2: '1984-03-15 → March 15, 1984',
           mapsToPlandayFormat: 'MM/DD/YYYY'
         },
         option2: {
           format: 'YYYY-DD-MM',
           description: 'Year-Day-Month format',
-          example1: `${sample} → ${year}-${part2}-${part1} (${getMonthName(part2)} ${parseInt(part1)}, ${year})`,
-          example2: '1984-15-03 → 1984-03-15 (March 15, 1984)',
+          example1: `${sample} → ${getMonthName(part2)} ${parseInt(part1)}, ${year}`,
+          example2: '1984-15-03 → March 15, 1984',
           mapsToPlandayFormat: 'DD/MM/YYYY'
         }
       };
@@ -175,15 +175,15 @@ function detectFormatOptions(samples: string[]): { option1: FormatOption; option
         option1: {
           format: 'MM-DD-YYYY',
           description: 'Month-Day-Year format',
-          example1: `${sample} → ${year}-${part1}-${part2} (${getMonthName(part1)} ${parseInt(part2)}, ${year})`,
-          example2: '03-15-1984 → 1984-03-15 (March 15, 1984)',
+          example1: `${sample} → ${getMonthName(part1)} ${parseInt(part2)}, ${year}`,
+          example2: '03-15-1984 → March 15, 1984',
           mapsToPlandayFormat: 'MM/DD/YYYY'
         },
         option2: {
           format: 'DD-MM-YYYY',
           description: 'Day-Month-Year format',
-          example1: `${sample} → ${year}-${part2}-${part1} (${getMonthName(part2)} ${parseInt(part1)}, ${year})`,
-          example2: '15-03-1984 → 1984-03-15 (March 15, 1984)',
+          example1: `${sample} → ${getMonthName(part2)} ${parseInt(part1)}, ${year}`,
+          example2: '15-03-1984 → March 15, 1984',
           mapsToPlandayFormat: 'DD/MM/YYYY'
         }
       };
@@ -202,15 +202,15 @@ function detectFormatOptions(samples: string[]): { option1: FormatOption; option
         option1: {
           format: 'YYYYMMDD',
           description: 'Year Month Day (8-digit)',
-          example1: `${sample} → ${year}-${part1}-${part2} (${getMonthName(part1)} ${parseInt(part2)}, ${year})`,
-          example2: '19840315 → 1984-03-15 (March 15, 1984)',
+          example1: `${sample} → ${getMonthName(part1)} ${parseInt(part2)}, ${year}`,
+          example2: '19840315 → March 15, 1984',
           mapsToPlandayFormat: 'MM/DD/YYYY'
         },
         option2: {
           format: 'YYYYDDMM',
           description: 'Year Day Month (8-digit)',
-          example1: `${sample} → ${year}-${part2}-${part1} (${getMonthName(part2)} ${parseInt(part1)}, ${year})`,
-          example2: '19841503 → 1984-03-15 (March 15, 1984)',
+          example1: `${sample} → ${getMonthName(part2)} ${parseInt(part1)}, ${year}`,
+          example2: '19841503 → March 15, 1984',
           mapsToPlandayFormat: 'DD/MM/YYYY'
         }
       };
@@ -224,15 +224,15 @@ function detectFormatOptions(samples: string[]): { option1: FormatOption; option
         option1: {
           format: 'MMDDYYYY',
           description: 'Month Day Year (8-digit)',
-          example1: `${sample} → ${year}-${part1}-${part2} (${getMonthName(part1)} ${parseInt(part2)}, ${year})`,
-          example2: '03151984 → 1984-03-15 (March 15, 1984)',
+          example1: `${sample} → ${getMonthName(part1)} ${parseInt(part2)}, ${year}`,
+          example2: '03151984 → March 15, 1984',
           mapsToPlandayFormat: 'MM/DD/YYYY'
         },
         option2: {
           format: 'DDMMYYYY',
           description: 'Day Month Year (8-digit)',
-          example1: `${sample} → ${year}-${part2}-${part1} (${getMonthName(part2)} ${parseInt(part1)}, ${year})`,
-          example2: '15031984 → 1984-03-15 (March 15, 1984)',
+          example1: `${sample} → ${getMonthName(part2)} ${parseInt(part1)}, ${year}`,
+          example2: '15031984 → March 15, 1984',
           mapsToPlandayFormat: 'DD/MM/YYYY'
         }
       };
@@ -245,14 +245,14 @@ function detectFormatOptions(samples: string[]): { option1: FormatOption; option
       format: 'MM/DD/YYYY',
       description: 'US format - Month/Day/Year',
       example1: `${sample} → (Month first interpretation)`,
-      example2: '03/15/1984 → 1984-03-15 (March 15, 1984)',
+      example2: '03/15/1984 → March 15, 1984',
       mapsToPlandayFormat: 'MM/DD/YYYY'
     },
     option2: {
       format: 'DD/MM/YYYY',
       description: 'European format - Day/Month/Year',
       example1: `${sample} → (Day first interpretation)`,
-      example2: '15/03/1984 → 1984-03-15 (March 15, 1984)',
+      example2: '15/03/1984 → March 15, 1984',
       mapsToPlandayFormat: 'DD/MM/YYYY'
     }
   };
@@ -307,12 +307,9 @@ export const DateFormatSelectionStep: React.FC<DateFormatSelectionStepProps> = (
             Date Format Selection Required
           </h3>
           <p className="text-gray-600">
-            Your Excel file contains ambiguous dates like "<strong>{exampleDate}</strong>" in date fields that could be interpreted in multiple ways. 
-            Please specify what format your <strong>source data</strong> is in so we can parse it correctly.
+            Your Excel file contains dates like "<strong>{exampleDate}</strong>" that could be read as either
+            month-first or day-first. Please tell us which one your <strong>source data</strong> uses so we read it correctly.
           </p>
-          <div className="text-sm text-gray-500 mt-2">
-            (All dates will be converted to YYYY-MM-DD format for Planday)
-          </div>
         </div>
       </Card>
 

--- a/src/services/excelParser.ts
+++ b/src/services/excelParser.ts
@@ -1202,8 +1202,11 @@ export class ExcelParser {
     flags: { hasDate: boolean; hasNumber: boolean; hasText: boolean }
   ): ExcelColumnType {
     if (flags.hasDate) return 'date';
-    if (flags.hasNumber && !flags.hasText) return 'numeric';
-    if (flags.hasText || flags.hasNumber) return 'text';
+    // Any number present marks the column 'numeric' so serials still convert in
+    // partially dirty columns (e.g. 46113 mixed with text); the per-value guard
+    // in MappingStep leaves non-numeric cells untouched for the ambiguity flow.
+    if (flags.hasNumber) return 'numeric';
+    if (flags.hasText) return 'text';
     return 'empty';
   }
 

--- a/src/services/excelParser.ts
+++ b/src/services/excelParser.ts
@@ -25,6 +25,7 @@ import type {
   ExcelColumnMapping,
   ValidationError,
   PlandayEmployeeCreateRequest,
+  ExcelColumnType,
 } from '../types/planday';
 import { VALIDATION_CONFIG } from '../constants';
 import { AUTO_MAPPING_RULES } from '../constants/autoMappingRules';
@@ -130,21 +131,39 @@ export class ExcelParser {
 
       // Extract all data as a 2D array
       const rawData: any[][] = [];
-      
+
+      // Track the source Excel value type per column so date handling can later
+      // branch on real date cells vs. raw serial numbers vs. free text, rather
+      // than re-guessing from a value that has been flattened to a string.
+      const columnTypeFlags: Array<{ hasDate: boolean; hasNumber: boolean; hasText: boolean }> =
+        Array.from({ length: columnCount }, () => ({ hasDate: false, hasNumber: false, hasText: false }));
+
       // Read all rows
       for (let rowNum = 1; rowNum <= rowCount; rowNum++) {
         const row = worksheet.getRow(rowNum);
         const rowData: any[] = [];
-        
+
         // Read all columns in this row
         for (let colNum = 1; colNum <= columnCount; colNum++) {
           const cell = row.getCell(colNum);
           const cellValue = this.extractCellValue(cell);
           rowData.push(cellValue);
+
+          // Classify the source cell type (data rows only, skip the header row)
+          if (rowNum > 1) {
+            this.recordCellType(cell, columnTypeFlags[colNum - 1]);
+          }
         }
-        
+
         rawData.push(rowData);
       }
+
+      // Whether the workbook uses the 1904 date system (affects serial → date).
+      const date1904 = Boolean(
+        (worksheet as any)?.properties?.date1904 ??
+        (workbook as any)?.properties?.date1904 ??
+        false
+      );
 
       // Check for empty file
       if (rawData.length === 0) {
@@ -239,9 +258,15 @@ export class ExcelParser {
 
       // Keep only headers and data for columns that have actual data
       const headers = columnsWithData.map(col => col.header);
-      const filteredRows = nonEmptyRows.map(row => 
+      const filteredRows = nonEmptyRows.map(row =>
         columnsWithData.map(col => row[col.index])
       );
+
+      // Map the captured source types onto the surviving (non-empty) columns
+      const columnExcelTypes: Record<string, ExcelColumnType> = {};
+      columnsWithData.forEach(col => {
+        columnExcelTypes[col.header] = this.classifyColumnType(columnTypeFlags[col.index]);
+      });
 
       const result: ParsedExcelData = {
         headers,
@@ -250,7 +275,9 @@ export class ExcelParser {
         fileName: file.name,
         fileSize: file.size,
         columnAnalysis, // Include analysis for debugging/info
-        discardedColumns: emptyColumns.map(col => col.header)
+        discardedColumns: emptyColumns.map(col => col.header),
+        columnExcelTypes,
+        date1904
       };
 
       console.log(`✅ Excel parsing complete: ${result.totalRows} rows, ${result.headers.length} columns with data`);
@@ -1124,6 +1151,60 @@ export class ExcelParser {
 
     // Fallback to string conversion
     return String(value);
+  }
+
+  /**
+   * Record the source Excel value type for a cell into a per-column tally.
+   * ExcelJS reports real date cells as ValueType.Date and "General"-formatted
+   * date serials as ValueType.Number, which lets us distinguish them later.
+   */
+  private static recordCellType(
+    cell: ExcelJS.Cell,
+    flags: { hasDate: boolean; hasNumber: boolean; hasText: boolean }
+  ): void {
+    if (!cell || cell.value === null || cell.value === undefined) {
+      return;
+    }
+
+    let type = cell.type;
+    // Unwrap formula cells to the type of their computed result.
+    if (type === ExcelJS.ValueType.Formula) {
+      const result = (cell.value as any)?.result;
+      if (result instanceof Date) type = ExcelJS.ValueType.Date;
+      else if (typeof result === 'number') type = ExcelJS.ValueType.Number;
+      else if (typeof result === 'string' && result.trim()) type = ExcelJS.ValueType.String;
+      else return;
+    }
+
+    switch (type) {
+      case ExcelJS.ValueType.Date:
+        flags.hasDate = true;
+        break;
+      case ExcelJS.ValueType.Number:
+        flags.hasNumber = true;
+        break;
+      case ExcelJS.ValueType.String:
+      case ExcelJS.ValueType.SharedString:
+      case ExcelJS.ValueType.RichText:
+      case ExcelJS.ValueType.Hyperlink:
+        if (cell.text && cell.text.trim()) flags.hasText = true;
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Reduce a column's per-cell type tally to a single source classification.
+   * Real date cells win over numbers (serials), which win over free text.
+   */
+  private static classifyColumnType(
+    flags: { hasDate: boolean; hasNumber: boolean; hasText: boolean }
+  ): ExcelColumnType {
+    if (flags.hasDate) return 'date';
+    if (flags.hasNumber && !flags.hasText) return 'numeric';
+    if (flags.hasText || flags.hasNumber) return 'text';
+    return 'empty';
   }
 
   /**

--- a/src/types/planday.ts
+++ b/src/types/planday.ts
@@ -385,7 +385,15 @@ export interface ParsedExcelData {
     sampleData: any[];
   }>;
   discardedColumns?: string[];
+  // Source Excel cell type per column (keyed by header). Lets the validation
+  // pipeline branch on how a date was stored (real date cell vs. raw serial
+  // number vs. free text) instead of guessing from a stringified value.
+  columnExcelTypes?: Record<string, ExcelColumnType>;
+  // Workbook date epoch flag (false = 1900 system, true = 1904 system).
+  date1904?: boolean;
 }
+
+export type ExcelColumnType = 'date' | 'numeric' | 'text' | 'empty';
 
 export interface ValidationResult {
   isValid: boolean;

--- a/src/utils/dateParser.ts
+++ b/src/utils/dateParser.ts
@@ -23,6 +23,38 @@ export class DateParser {
   }
   
   /**
+   * Convert a raw Excel date serial number to an ISO (YYYY-MM-DD) string.
+   *
+   * Used for "General"/Number-formatted cells that hold a date as a bare serial
+   * (e.g. 46113 → 2026-04-01). The month/day order is unambiguous, so these never
+   * need the format picker. Returns null for values outside the valid Excel range.
+   *
+   * The 25569 offset is the Excel serial for 1970-01-01 and already bakes in the
+   * Excel 1900 leap-year bug for all serials past 1900-02-28, so it is correct for
+   * every real-world employee date. The 1904 system shifts the epoch by 1462 days.
+   */
+  static excelSerialToISO(serial: number, date1904 = false): string | null {
+    if (!Number.isFinite(serial) || serial < 1 || serial > 2958465) {
+      return null;
+    }
+
+    const epochOffset = date1904 ? 24107 : 25569;
+    const ms = Math.round((serial - epochOffset) * 86400000);
+    const date = new Date(ms);
+
+    if (isNaN(date.getTime())) {
+      return null;
+    }
+
+    // Use UTC getters: the serial maps to a UTC-midnight instant, so UTC parts
+    // give the intended calendar date in every timezone.
+    const year = date.getUTCFullYear();
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(date.getUTCDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  /**
    * Check if a value could be a date in any supported format
    */
   static couldBeDate(value: string): boolean {

--- a/src/utils/dateParser.ts
+++ b/src/utils/dateParser.ts
@@ -34,11 +34,19 @@ export class DateParser {
    * every real-world employee date. The 1904 system shifts the epoch by 1462 days.
    */
   static excelSerialToISO(serial: number, date1904 = false): string | null {
-    if (!Number.isFinite(serial) || serial < 1 || serial > 2958465) {
+    const minSerial = date1904 ? 0 : 1;
+    if (!Number.isFinite(serial) || serial < minSerial || serial > 2958465) {
       return null;
     }
 
-    const epochOffset = date1904 ? 24107 : 25569;
+    // 1900 mode: serial 60 is Excel's fictitious 1900-02-29 (the leap-year bug)
+    // and has no real date; serials 1..59 predate it, so shift the epoch back a
+    // day. The 25569 offset (1970-01-01) is correct from serial 61 onward.
+    if (!date1904 && serial === 60) {
+      return null;
+    }
+
+    const epochOffset = date1904 ? 24107 : (serial < 60 ? 25568 : 25569);
     const ms = Math.round((serial - epochOffset) * 86400000);
     const date = new Date(ms);
 

--- a/src/utils/datePatternAnalyzer.ts
+++ b/src/utils/datePatternAnalyzer.ts
@@ -112,9 +112,12 @@ export class DatePatternAnalyzer {
       return false;
     }
     
-    // All supported ambiguous date patterns
+    // Year-FIRST dates (YYYY-MM-DD and friends) are treated as canonical ISO and
+    // are NOT ambiguous: this is the form every real Excel date cell is converted
+    // to, and YYYY-DD-MM is not a real-world format. Excluding it here stops the
+    // picker from appearing for date-typed columns (issue #25). Only genuinely
+    // ambiguous year-last and 8-digit text patterns reach the picker.
     const ambiguousPatterns = [
-      /^\d{4}[/\-.]\d{1,2}[/\-.]\d{1,2}$/,     // YYYY-MM-DD vs YYYY-DD-MM
       /^\d{1,2}[/\-.]\d{1,2}[/\-.]\d{2,4}$/,   // MM/DD/YYYY vs DD/MM/YYYY
       /^\d{8}$/                                     // 8-digit patterns
     ];


### PR DESCRIPTION
## Summary

Fixes #25. Branches date handling on **how a date was stored in the source file** (real date cell vs. raw serial number vs. free text) instead of re-guessing from a value that has already been flattened to a string.

Before, every cell was normalised to a `YYYY-MM-DD` string very early, collapsing three genuinely different source cases into one lossy path:
- **Real date cells** were re-examined by the ambiguity analyzer and triggered the format picker for any date where both parts are ≤ 12 (e.g. `2020-05-03`) — asking a question the file had already answered.
- **General/Number-formatted serials** (e.g. `46113`) matched no string date pattern and were silently treated as meaningless numbers.
- **Text dates** (`05/03/2020`) — the only genuinely ambiguous case — were lumped in with the rest.

## Changes
- **`excelParser.ts`** — captures each column's source Excel type (`date` / `numeric` / `text`) and the workbook `date1904` flag during extraction (before `normalizeCellValue` stringifies everything), exposed on `ParsedExcelData`.
- **`dateParser.ts`** — `excelSerialToISO()` converts raw serials to ISO using UTC-based math and the standard `25569` epoch offset (correct for every real-world employee date).
- **`MappingStep.tsx`** — converts serials from numeric date columns to ISO up front, bounded so an 8-digit `YYYYMMDD` typed as a number still flows to the existing parser. Real date cells already arrive as ISO; text columns are left untouched for the ambiguity flow.
- **`datePatternAnalyzer.ts`** — stops treating canonical year-first `YYYY-MM-DD` (the form every real date cell becomes) as ambiguous, so date-typed columns never reach the picker. Only genuinely ambiguous year-last / 8-digit **text** dates do.
- **`DateFormatSelectionStep.tsx`** — examples now read in plain language (`01/02/1984 → January 2, 1984`) instead of exposing the internal `→ 1984-01-02` payload; removed the "converted to YYYY-MM-DD" note.

## Timezone correctness
Verified empirically with ExcelJS 4.4.0: date cells use `getUTC*` correctly — local getters would shift April 1 → March 31 in UTC-negative zones. The existing UTC handling is right and was kept. The "use local getters" advice from the original SheetJS write-up is backwards for ExcelJS, as the issue suspected.

## Test plan
No automated test framework in this repo (client-side only, manual testing). Verification done:
- [x] `npm run build` (tsc + vite) passes; ESLint clean (0 errors).
- [x] Node harness builds a 3-column `.xlsx` (date-formatted / General / text, all `01/04/2026`) and confirms across UTC / America/Los_Angeles / Asia/Tokyo: the date and General/serial columns both resolve to `2026-04-01` with no picker; only the text column reaches the picker.
- [ ] Manual in-app check with the reporter's original file (UI flow not exercised in this environment).

https://claude.ai/code/session_01J5aV6MM65rHS5oMfPaqB65

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5aV6MM65rHS5oMfPaqB65)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Excel date import with automatic detection and conversion of date formats.
  * Improved date format selection UI with clearer, localized example dates for user guidance.

* **Bug Fixes**
  * More accurate date parsing from Excel files by properly identifying date cells versus numeric values.
  * Better support for different Excel date system standards (1900 and 1904 formats).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lushbits/pdbulkupload/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->