### PR TITLE
Enforce unique email + SSN and require at least one department

### DIFF
--- a/src/components/validation/DataCorrectionStep.tsx
+++ b/src/components/validation/DataCorrectionStep.tsx
@@ -77,6 +77,7 @@ export const DataCorrectionStep: React.FC<DataCorrectionStepProps> = ({
   // New state for duplicate checking
   const [isCheckingDuplicates, setIsCheckingDuplicates] = useState(false);
   const [existingEmployees, setExistingEmployees] = useState<Map<string, PlandayEmployeeResponse>>(new Map());
+  const [existingSsnEmployees, setExistingSsnEmployees] = useState<Map<string, PlandayEmployeeResponse>>(new Map());
   
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -99,18 +100,31 @@ export const DataCorrectionStep: React.FC<DataCorrectionStepProps> = ({
           .map(emp => emp.email)
           .filter(email => email && email.trim() !== '')
           .map(email => email!.toLowerCase().trim());
-        
-        if (emailAddresses.length === 0) {
+
+        // Extract SSNs (exact-string, no normalization beyond dropping empties)
+        const ssnValues = employees
+          .map(emp => (emp as any).ssn)
+          .filter(ssn => ssn !== null && ssn !== undefined && String(ssn).trim() !== '')
+          .map(ssn => String(ssn));
+
+        if (emailAddresses.length === 0 && ssnValues.length === 0) {
           setIsCheckingDuplicates(false);
           return;
         }
-        
-        // Check for existing employees
-        const existingEmps = await plandayApi.checkExistingEmployeesByEmail(emailAddresses);
-        setExistingEmployees(existingEmps);
-        
+
+        // Check for existing employees by email and SSN
+        if (emailAddresses.length > 0) {
+          const existingEmps = await plandayApi.checkExistingEmployeesByEmail(emailAddresses);
+          setExistingEmployees(existingEmps);
+        }
+
+        if (ssnValues.length > 0) {
+          const existingSsnEmps = await plandayApi.checkExistingEmployeesBySsn(ssnValues);
+          setExistingSsnEmployees(existingSsnEmps);
+        }
+
         // Existing employees check completed
-        
+
       } catch (error) {
         console.error('❌ Failed to check for existing employees:', error);
         // Don't block validation if duplicate check fails - just log and continue
@@ -131,7 +145,7 @@ export const DataCorrectionStep: React.FC<DataCorrectionStepProps> = ({
     validateAllEmployees().catch(error => {
       console.error('❌ Validation failed:', error);
     });
-  }, [employees, existingEmployees]); // Re-validate when existing employees data changes
+  }, [employees, existingEmployees, existingSsnEmployees]); // Re-validate when existing employees data changes
 
   // Focus input when editing cell (only on initial edit start)
   useEffect(() => {
@@ -254,8 +268,19 @@ export const DataCorrectionStep: React.FC<DataCorrectionStepProps> = ({
         console.warn(`⚠️ Custom field warnings for employee at row ${index}:`, customFieldResult.warnings);
       }
 
-      // NOTE: Department/employee group validation is handled in the bulk correction phase
-      // Individual validation should only check format/field-level issues, not name-to-ID mapping
+      // Every employee must have at least one department. This is a field-level
+      // emptiness check (not name-to-ID mapping, which stays in the bulk phase), so
+      // clearing the departments cell re-flags the row live and refilling clears it.
+      const departmentsValue = (employee as any).departments;
+      if (!departmentsValue || departmentsValue.toString().trim() === '') {
+        errors.push({
+          field: 'departments',
+          value: '',
+          message: 'At least one department must be assigned to each employee',
+          rowIndex: index,
+          severity: 'error'
+        });
+      }
 
       if (errors.length > 0) {
         newValidationErrors.set(employeeKey, errors);
@@ -285,8 +310,20 @@ export const DataCorrectionStep: React.FC<DataCorrectionStepProps> = ({
       });
     }
 
+    // Validate against existing SSNs in Planday (duplicate checking)
+    if (existingSsnEmployees.size > 0) {
+      const existingSsnErrors = ValidationService.validateExistingEmployeesBySsn(employees, existingSsnEmployees);
+
+      existingSsnErrors.forEach(error => {
+        const employeeKey = `employee-${error.rowIndex}`;
+        const existingErrors = newValidationErrors.get(employeeKey) || [];
+        existingErrors.push(error);
+        newValidationErrors.set(employeeKey, existingErrors);
+      });
+    }
+
     setValidationErrors(newValidationErrors);
-  }, [employees, existingEmployees]);
+  }, [employees, existingEmployees, existingSsnEmployees]);
 
   /**
    * Handle cell click to start editing
@@ -360,6 +397,35 @@ export const DataCorrectionStep: React.FC<DataCorrectionStepProps> = ({
   }, [plandayApi]);
 
   /**
+   * Re-check Planday for specific SSNs (exact-string match, no normalization)
+   */
+  const recheckDuplicatesForSsns = useCallback(async (ssnValues: string[]) => {
+    if (!plandayApi.isAuthenticated || ssnValues.length === 0) return;
+
+    try {
+      const existingSsnEmps = await plandayApi.checkExistingEmployeesBySsn(ssnValues);
+
+      setExistingSsnEmployees(prev => {
+        const updated = new Map(prev);
+
+        // Remove old entries for the checked SSNs
+        ssnValues.forEach(ssn => {
+          updated.delete(String(ssn));
+        });
+
+        // Add new entries if duplicates were found
+        existingSsnEmps.forEach((employee, ssn) => {
+          updated.set(ssn, employee);
+        });
+
+        return updated;
+      });
+    } catch (error) {
+      console.error('❌ Failed to re-check SSN duplicates:', error);
+    }
+  }, [plandayApi]);
+
+  /**
    * Commit cell edit
    */
   const commitCellEdit = useCallback(() => {
@@ -403,8 +469,26 @@ export const DataCorrectionStep: React.FC<DataCorrectionStepProps> = ({
       }
     }
 
+    // If SSN field was modified, re-check Planday for the new value (exact-string)
+    if (field === 'ssn' && value !== oldValue) {
+      // Drop the old SSN from the existing-SSN map if it was flagged
+      if (oldValue !== null && oldValue !== undefined && String(oldValue).trim() !== '') {
+        const oldSsn = String(oldValue);
+        setExistingSsnEmployees(prev => {
+          const updated = new Map(prev);
+          updated.delete(oldSsn);
+          return updated;
+        });
+      }
+
+      // Check the new SSN against Planday if non-empty
+      if (value !== null && value !== undefined && String(value).trim() !== '') {
+        recheckDuplicatesForSsns([String(value)]);
+      }
+    }
+
     setEditingCell(null);
-  }, [editingCell, employees, recheckDuplicatesForEmails]);
+  }, [editingCell, employees, recheckDuplicatesForEmails, recheckDuplicatesForSsns]);
 
   /**
    * Cancel cell edit

--- a/src/components/validation/DataCorrectionStep.tsx
+++ b/src/components/validation/DataCorrectionStep.tsx
@@ -78,6 +78,7 @@ export const DataCorrectionStep: React.FC<DataCorrectionStepProps> = ({
   const [isCheckingDuplicates, setIsCheckingDuplicates] = useState(false);
   const [existingEmployees, setExistingEmployees] = useState<Map<string, PlandayEmployeeResponse>>(new Map());
   const [existingSsnEmployees, setExistingSsnEmployees] = useState<Map<string, PlandayEmployeeResponse>>(new Map());
+  const [ssnCheckUnavailable, setSsnCheckUnavailable] = useState(false);
   
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -119,8 +120,9 @@ export const DataCorrectionStep: React.FC<DataCorrectionStepProps> = ({
         }
 
         if (ssnValues.length > 0) {
-          const existingSsnEmps = await plandayApi.checkExistingEmployeesBySsn(ssnValues);
-          setExistingSsnEmployees(existingSsnEmps);
+          const ssnResult = await plandayApi.checkExistingEmployeesBySsn(ssnValues);
+          setExistingSsnEmployees(ssnResult.existing);
+          setSsnCheckUnavailable(!ssnResult.available);
         }
 
         // Existing employees check completed
@@ -403,7 +405,8 @@ export const DataCorrectionStep: React.FC<DataCorrectionStepProps> = ({
     if (!plandayApi.isAuthenticated || ssnValues.length === 0) return;
 
     try {
-      const existingSsnEmps = await plandayApi.checkExistingEmployeesBySsn(ssnValues);
+      const ssnResult = await plandayApi.checkExistingEmployeesBySsn(ssnValues);
+      setSsnCheckUnavailable(!ssnResult.available);
 
       setExistingSsnEmployees(prev => {
         const updated = new Map(prev);
@@ -414,7 +417,7 @@ export const DataCorrectionStep: React.FC<DataCorrectionStepProps> = ({
         });
 
         // Add new entries if duplicates were found
-        existingSsnEmps.forEach((employee, ssn) => {
+        ssnResult.existing.forEach((employee, ssn) => {
           updated.set(ssn, employee);
         });
 
@@ -914,6 +917,22 @@ export const DataCorrectionStep: React.FC<DataCorrectionStepProps> = ({
             </div>
             <p className="text-yellow-700 text-sm mt-2">
               Click <strong>Skip Duplicates</strong> to exclude them from upload while keeping them visible for review.
+            </p>
+          </div>
+        )}
+
+        {/* SSN duplicate check unavailable (protected scope not granted) */}
+        {!isCheckingDuplicates && ssnCheckUnavailable && (
+          <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-4">
+            <div className="flex items-center">
+              <span className="text-amber-600 text-lg mr-2">⚠️</span>
+              <span className="text-amber-800 font-medium">
+                SSN check skipped — this Planday connection can't read existing SSNs
+              </span>
+            </div>
+            <p className="text-amber-700 text-sm mt-2">
+              Duplicate SSNs <strong>within this file</strong> are still flagged, but rows whose SSN already
+              exists in Planday can't be detected without the SSN access scope. Verify these manually if needed.
             </p>
           </div>
         )}

--- a/src/hooks/usePlandayApi.ts
+++ b/src/hooks/usePlandayApi.ts
@@ -21,6 +21,7 @@ import type {
   PlandaySalaryType,
   PlandayContractRule,
   PlandayEmployeeResponse,
+  SsnExistenceCheckResult,
   PlandayEmployeeCreateRequest,
   EmployeeUploadResult,
   BulkUploadProgress,
@@ -137,7 +138,7 @@ interface PlandayApiActions {
 
   checkExistingEmployeesBySsn: (
     ssnValues: string[]
-  ) => Promise<Map<string, PlandayEmployeeResponse>>;
+  ) => Promise<SsnExistenceCheckResult>;
 
   // Pay rate actions
   bulkSetPayrates: (
@@ -999,7 +1000,7 @@ export const usePlandayApi = (): UsePlandayApiReturn => {
    */
   const checkExistingEmployeesBySsn = useCallback(async (
     ssnValues: string[]
-  ): Promise<Map<string, PlandayEmployeeResponse>> => {
+  ): Promise<SsnExistenceCheckResult> => {
     if (!state.isAuthenticated) {
       throw new Error('Not authenticated. Please authenticate first.');
     }
@@ -1009,7 +1010,7 @@ export const usePlandayApi = (): UsePlandayApiReturn => {
     } catch (error) {
       // Don't block the upload flow if the SSN lookup can't run.
       console.warn('⚠️ Failed to check existing employees by SSN:', error);
-      return new Map<string, PlandayEmployeeResponse>();
+      return { existing: new Map<string, PlandayEmployeeResponse>(), available: false };
     }
   }, [state.isAuthenticated]);
 

--- a/src/hooks/usePlandayApi.ts
+++ b/src/hooks/usePlandayApi.ts
@@ -134,7 +134,11 @@ interface PlandayApiActions {
   checkExistingEmployeesByEmail: (
     emailAddresses: string[]
   ) => Promise<Map<string, PlandayEmployeeResponse>>;
-  
+
+  checkExistingEmployeesBySsn: (
+    ssnValues: string[]
+  ) => Promise<Map<string, PlandayEmployeeResponse>>;
+
   // Pay rate actions
   bulkSetPayrates: (
     assignments: PayrateAssignment[],
@@ -990,6 +994,26 @@ export const usePlandayApi = (): UsePlandayApiReturn => {
   }, [state.isAuthenticated, handleError]);
 
   /**
+   * Check if employees with specific SSNs already exist in Planday.
+   * Degrades gracefully (returns empty map) if the SSN scope is unavailable.
+   */
+  const checkExistingEmployeesBySsn = useCallback(async (
+    ssnValues: string[]
+  ): Promise<Map<string, PlandayEmployeeResponse>> => {
+    if (!state.isAuthenticated) {
+      throw new Error('Not authenticated. Please authenticate first.');
+    }
+
+    try {
+      return await PlandayApi.checkExistingEmployeesBySsn(ssnValues);
+    } catch (error) {
+      // Don't block the upload flow if the SSN lookup can't run.
+      console.warn('⚠️ Failed to check existing employees by SSN:', error);
+      return new Map<string, PlandayEmployeeResponse>();
+    }
+  }, [state.isAuthenticated]);
+
+  /**
    * Bulk set pay rates for employees in employee groups
    */
   const bulkSetPayrates = useCallback(async (
@@ -1282,6 +1306,7 @@ export const usePlandayApi = (): UsePlandayApiReturn => {
     fetchEmployees,
     fetchEmployeesByIds,
     checkExistingEmployeesByEmail,
+    checkExistingEmployeesBySsn,
     bulkSetPayrates,
     bulkAssignSupervisors,
     bulkAssignFixedSalaries,

--- a/src/services/mappingService.ts
+++ b/src/services/mappingService.ts
@@ -1194,17 +1194,15 @@ export class MappingService {
       // Always create editable field, even if empty
       converted.departments = '';
       converted.__departmentsIds = [];
-      // Validate that at least one department is assigned
-      const hasDepartmentFields = Object.keys(employee).some(key => key.startsWith('departments.'));
-      if (hasDepartmentFields) {
-        errors.push({
-          field: 'departments' as any,
-          value: '',
-          message: 'At least one department must be assigned to each employee',
-          rowIndex: employee.rowIndex || 0,
-          severity: 'error'
-        });
-      }
+      // Every employee must have at least one department (required by Planday),
+      // even when no department column was mapped at all.
+      errors.push({
+        field: 'departments' as any,
+        value: '',
+        message: 'At least one department must be assigned to each employee',
+        rowIndex: employee.rowIndex || 0,
+        severity: 'error'
+      });
     }
 
     // Handle employee groups - NEW: Individual field approach with hourly rate support
@@ -3712,20 +3710,26 @@ export class ValidationService {
    */
   static validateUniqueFields(employees: any[]): ValidationError[] {
     const errors: ValidationError[] = [];
-    const uniqueFields = this.getUniqueFields();
+    // Always enforce email and ssn uniqueness in-file, even if the portal schema
+    // doesn't flag them as unique. ssn compares exact-string (no normalization),
+    // unlike the lowercase+trim applied to email and schema-driven unique fields.
+    const uniqueFields = new Set<string>([...this.getUniqueFields(), 'email', 'ssn']);
 
     for (const fieldName of uniqueFields) {
       const valueMap = new Map<string, number[]>();
-      
+      const isSsn = fieldName === 'ssn';
+
       // Collect all values for this field
       employees.forEach((employee, index) => {
-        const value = employee[fieldName];
-        if (value && typeof value === 'string' && value.trim() !== '') {
-          const normalizedValue = value.trim().toLowerCase();
-          const indices = valueMap.get(normalizedValue) || [];
-          indices.push(index);
-          valueMap.set(normalizedValue, indices);
-        }
+        const rawValue = employee[fieldName];
+        if (rawValue === null || rawValue === undefined) return;
+        const stringValue = String(rawValue);
+        if (stringValue.trim() === '') return;
+        // SSN must match character-sensitive (e.g. "123-45-6789" !== "123456789").
+        const key = isSsn ? stringValue : stringValue.trim().toLowerCase();
+        const indices = valueMap.get(key) || [];
+        indices.push(index);
+        valueMap.set(key, indices);
       });
 
       // Check for duplicates
@@ -3773,7 +3777,42 @@ export class ValidationService {
         }
       }
     });
-    
+
+    return errors;
+  }
+
+  /**
+   * Validate employees against existing Planday SSNs to check for duplicates.
+   * SSN is matched character-sensitive (no normalization), mirroring the in-file rule.
+   */
+  static validateExistingEmployeesBySsn(
+    employees: any[],
+    existingSsnEmployees: Map<string, any>
+  ): ValidationError[] {
+    const errors: ValidationError[] = [];
+
+    if (existingSsnEmployees.size === 0) {
+      return errors;
+    }
+
+    employees.forEach((employee, index) => {
+      const ssn = employee.ssn;
+      if (ssn === null || ssn === undefined) return;
+      const ssnValue = String(ssn);
+      if (ssnValue.trim() === '') return;
+
+      const existingEmployee = existingSsnEmployees.get(ssnValue);
+      if (existingEmployee) {
+        errors.push({
+          field: 'ssn',
+          value: ssn,
+          message: `Employee with SSN "${ssnValue}" already exists in Planday (ID: ${existingEmployee.id}, Name: ${existingEmployee.firstName} ${existingEmployee.lastName})`,
+          rowIndex: index,
+          severity: 'error'
+        });
+      }
+    });
+
     return errors;
   }
 

--- a/src/services/plandayApi.ts
+++ b/src/services/plandayApi.ts
@@ -652,16 +652,18 @@ export class PlandayApiClient {
    * Fetch employees from Planday with pagination
    * Used for verification after upload to ensure employees were created correctly
    */
-  async fetchEmployees(limit: number = 100, offset: number = 0): Promise<{
+  async fetchEmployees(limit: number = 100, offset: number = 0, special?: string): Promise<{
     employees: PlandayEmployeeResponse[];
     total: number;
     hasMore: boolean;
   }> {
     try {
+      // `special` requests protected fields (e.g. "Ssn") that need an extra OAuth scope.
+      const specialParam = special ? `&Special=${encodeURIComponent(special)}` : '';
       const response = await this.makeAuthenticatedRequest<{
         paging: { offset: number; limit: number; total: number };
         data: PlandayEmployeeResponse[];
-      }>(`${API_ENDPOINTS.EMPLOYEES}?limit=${limit}&offset=${offset}`);
+      }>(`${API_ENDPOINTS.EMPLOYEES}?limit=${limit}&offset=${offset}${specialParam}`);
       
       return {
         employees: response.data,
@@ -730,10 +732,70 @@ export class PlandayApiClient {
       // Existing employee check completed
       
       return existingEmployees;
-      
+
     } catch (error) {
       console.error('❌ Failed to check existing employees by email:', error);
       throw error;
+    }
+  }
+
+  /**
+   * Check if employees with specific SSNs already exist in Planday.
+   * Returns a map of SSN -> existing employee data (exact-string keys, no normalization).
+   *
+   * SSN is a protected field requiring an extra OAuth scope. If the portal/token
+   * doesn't grant it (request fails, or records omit ssn), this degrades gracefully
+   * by returning whatever it could match rather than hard-failing the upload flow.
+   */
+  async checkExistingEmployeesBySsn(ssnValues: string[]): Promise<Map<string, PlandayEmployeeResponse>> {
+    const existingEmployees = new Map<string, PlandayEmployeeResponse>();
+
+    // Exact-match set; only normalization is dropping empty/whitespace entries.
+    const wantedSsns = new Set<string>();
+    ssnValues.forEach(value => {
+      if (value !== null && value !== undefined && String(value).trim() !== '') {
+        wantedSsns.add(String(value));
+      }
+    });
+
+    if (wantedSsns.size === 0) {
+      return existingEmployees;
+    }
+
+    try {
+      let offset = 0;
+      const limit = 50; // Planday API maximum is 50 records per request
+      let hasMore = true;
+
+      while (hasMore) {
+        // Request the protected ssn field explicitly.
+        const result = await this.fetchEmployees(limit, offset, 'Ssn');
+
+        for (const employee of result.employees) {
+          const employeeSsn = (employee as any).ssn;
+          if (employeeSsn !== null && employeeSsn !== undefined) {
+            const ssnString = String(employeeSsn);
+            if (wantedSsns.has(ssnString)) {
+              existingEmployees.set(ssnString, employee);
+            }
+          }
+        }
+
+        hasMore = result.hasMore;
+        offset += limit;
+
+        // Add a small delay between batches to respect rate limits
+        if (hasMore) {
+          await this.delay(200);
+        }
+      }
+
+      return existingEmployees;
+
+    } catch (error) {
+      // Degrade gracefully: SSN scope may not be granted for this portal/token.
+      console.warn('⚠️ SSN existence check skipped (Planday may not return SSN for this token):', error);
+      return existingEmployees;
     }
   }
 
@@ -1631,12 +1693,12 @@ export const PlandayApi = {
   /**
    * Fetch employees for verification
    */
-  async fetchEmployees(limit: number = 100, offset: number = 0): Promise<{
+  async fetchEmployees(limit: number = 100, offset: number = 0, special?: string): Promise<{
     employees: PlandayEmployeeResponse[];
     total: number;
     hasMore: boolean;
   }> {
-    return plandayApiClient.fetchEmployees(limit, offset);
+    return plandayApiClient.fetchEmployees(limit, offset, special);
   },
 
   /**
@@ -1670,4 +1732,12 @@ export const PlandayApi = {
   async checkExistingEmployeesByEmail(emailAddresses: string[]): Promise<Map<string, PlandayEmployeeResponse>> {
     return plandayApiClient.checkExistingEmployeesByEmail(emailAddresses);
   },
-}; 
+
+  /**
+   * Check if employees with specific SSNs already exist in Planday
+   * Returns a map of SSN -> existing employee data
+   */
+  async checkExistingEmployeesBySsn(ssnValues: string[]): Promise<Map<string, PlandayEmployeeResponse>> {
+    return plandayApiClient.checkExistingEmployeesBySsn(ssnValues);
+  },
+};

--- a/src/services/plandayApi.ts
+++ b/src/services/plandayApi.ts
@@ -25,6 +25,7 @@ import type {
   PlandayContractRulesResponse,
   PlandayEmployeeCreateRequest,
   PlandayEmployeeResponse,
+  SsnExistenceCheckResult,
   BulkUploadProgress,
   EmployeeUploadResult,
   PlandayFieldDefinitionsSchema,
@@ -741,14 +742,17 @@ export class PlandayApiClient {
 
   /**
    * Check if employees with specific SSNs already exist in Planday.
-   * Returns a map of SSN -> existing employee data (exact-string keys, no normalization).
+   * Returns the matched SSNs (exact-string keys, no normalization) plus an
+   * `available` flag.
    *
    * SSN is a protected field requiring an extra OAuth scope. If the portal/token
-   * doesn't grant it (request fails, or records omit ssn), this degrades gracefully
-   * by returning whatever it could match rather than hard-failing the upload flow.
+   * doesn't grant it, the check degrades gracefully and reports `available: false`
+   * so the caller can surface a notice instead of treating it as "no duplicates":
+   *  - the request throws (e.g. 403), or
+   *  - employees are returned but none expose an `ssn` field at all.
    */
-  async checkExistingEmployeesBySsn(ssnValues: string[]): Promise<Map<string, PlandayEmployeeResponse>> {
-    const existingEmployees = new Map<string, PlandayEmployeeResponse>();
+  async checkExistingEmployeesBySsn(ssnValues: string[]): Promise<SsnExistenceCheckResult> {
+    const existing = new Map<string, PlandayEmployeeResponse>();
 
     // Exact-match set; only normalization is dropping empty/whitespace entries.
     const wantedSsns = new Set<string>();
@@ -759,24 +763,30 @@ export class PlandayApiClient {
     });
 
     if (wantedSsns.size === 0) {
-      return existingEmployees;
+      return { existing, available: true };
     }
 
     try {
       let offset = 0;
       const limit = 50; // Planday API maximum is 50 records per request
       let hasMore = true;
+      let sawEmployees = false;
+      let sawSsnField = false;
 
       while (hasMore) {
         // Request the protected ssn field explicitly.
         const result = await this.fetchEmployees(limit, offset, 'Ssn');
 
         for (const employee of result.employees) {
+          sawEmployees = true;
+          if ('ssn' in employee) {
+            sawSsnField = true;
+          }
           const employeeSsn = (employee as any).ssn;
           if (employeeSsn !== null && employeeSsn !== undefined) {
             const ssnString = String(employeeSsn);
             if (wantedSsns.has(ssnString)) {
-              existingEmployees.set(ssnString, employee);
+              existing.set(ssnString, employee);
             }
           }
         }
@@ -790,12 +800,17 @@ export class PlandayApiClient {
         }
       }
 
-      return existingEmployees;
+      // If the portal has employees but none expose ssn, the scope is withheld.
+      const available = !(sawEmployees && !sawSsnField);
+      if (!available) {
+        console.warn('⚠️ SSN existence check unavailable: employee records did not include SSN (scope likely not granted).');
+      }
+      return { existing, available };
 
     } catch (error) {
       // Degrade gracefully: SSN scope may not be granted for this portal/token.
       console.warn('⚠️ SSN existence check skipped (Planday may not return SSN for this token):', error);
-      return existingEmployees;
+      return { existing, available: false };
     }
   }
 
@@ -1737,7 +1752,7 @@ export const PlandayApi = {
    * Check if employees with specific SSNs already exist in Planday
    * Returns a map of SSN -> existing employee data
    */
-  async checkExistingEmployeesBySsn(ssnValues: string[]): Promise<Map<string, PlandayEmployeeResponse>> {
+  async checkExistingEmployeesBySsn(ssnValues: string[]): Promise<SsnExistenceCheckResult> {
     return plandayApiClient.checkExistingEmployeesBySsn(ssnValues);
   },
 };

--- a/src/types/planday.ts
+++ b/src/types/planday.ts
@@ -289,6 +289,17 @@ export interface PlandayEmployeeResponse {
 }
 
 /**
+ * Result of an SSN-vs-Planday existence check.
+ * `available` is false when SSN data couldn't be read (the protected SSN scope
+ * appears to be missing), so callers can surface a "check skipped" notice rather
+ * than treat the empty map as "no duplicates found".
+ */
+export interface SsnExistenceCheckResult {
+  existing: Map<string, PlandayEmployeeResponse>;
+  available: boolean;
+}
+
+/**
  * Employee Field Definitions Types
  * Based on Planday API: GET /hr/v1.0/employees/fielddefinitions
  */


### PR DESCRIPTION
Closes #28.

## Summary

Closes the three silent validation gaps described in #28 so duplicate emails/SSNs and department-less employees can't be written to a live Planday portal.

- **In-file email + SSN uniqueness** (`mappingService.ts`): `validateUniqueFields()` now always covers `email` (lowercase+trim) and `ssn` regardless of the portal's `unique` schema. SSN uses **exact-string** comparison, so `123-45-6789` and `123456789` are treated as different. Runs on every editor revalidation pass, so duplicates flag live and clear on fix.
- **SSN-vs-Planday existence check** (`plandayApi.ts`, `usePlandayApi.ts`, `mappingService.ts`, `DataCorrectionStep.tsx`): new `checkExistingEmployeesBySsn()` mirrors the email lookup — batches of 50 with the 200ms inter-batch delay and existing backoff/token-refresh — requesting the protected field via `Special=Ssn` and matching exact-string. New `validateExistingEmployeesBySsn()` surfaces per-row errors, wired into the editor with its own state and edit-rechecking.
- **Departments** (`mappingService.ts`, `DataCorrectionStep.tsx`): dropped the `hasDepartmentFields` guard so a missing department always errors — including when no department column was mapped — and added a live emptiness check in the editor pass so clearing the departments cell re-flags the row and refilling clears it.
- **Graceful degradation + notice**: the SSN check returns `{ existing, available }` so "ran fine, no duplicates" is distinct from "couldn't read SSNs." When the protected SSN scope is unavailable (request throws, or no record exposes an `ssn` field), an amber banner in the editor explains that in-Planday SSN duplicate detection was skipped while in-file SSN dedup still applies.

## Notes / judgment calls
- **No department column = hard error**, per the issue's stated outcome and because Planday requires departments. Easy to re-gate if a no-department portal config is legitimate.
- The "no `ssn` field on any record" heuristic for detecting a withheld scope depends on Planday's actual response shape (granted-but-empty vs. withheld), which couldn't be confirmed without a live portal.

## Test plan
- [ ] Two rows sharing an email are both flagged, live in the editor, regardless of portal schema
- [ ] Two rows sharing an exact SSN string are flagged; SSNs differing only by formatting (dashes) are not
- [ ] A row whose SSN already exists in Planday is flagged (when scope available)
- [ ] When the SSN scope is unavailable, the amber notice shows and in-file SSN dedup still works
- [ ] A row with no department is flagged, including when departments are cleared in the editor and when no department column was mapped
- [ ] All errors clear immediately once corrected

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015YywGU8Zy5Rh5G2hy4DHTW)_