### PR TITLE
Move step-back navigation to the top-left and demote the destructive reset

### DIFF
--- a/src/components/WorkflowApp.tsx
+++ b/src/components/WorkflowApp.tsx
@@ -5,8 +5,8 @@
  * This component handles the actual business logic while App.tsx handles routing
  */
 
-import { useState, useEffect } from 'react';
-import { Button, Card, ProgressIndicator, PrivacyModal, CookieModal, TermsOfServiceModal, VersionModal, getCurrentVersion, BetaBanner, BetaTag } from './ui';
+import { useState, useEffect, useRef } from 'react';
+import { Button, Card, ProgressIndicator, PrivacyModal, CookieModal, TermsOfServiceModal, VersionModal, getCurrentVersion, BetaBanner, BetaTag, ConfirmDialog } from './ui';
 import { AuthenticationStep } from './auth/AuthenticationStep';
 import { FileUploadStep } from './upload/FileUploadStep';
 import MappingStep from './mapping/MappingStep';
@@ -79,7 +79,23 @@ export function WorkflowApp({ onStepChange }: WorkflowAppProps = {}) {
   
   // Version modal state
   const [isVersionModalOpen, setIsVersionModalOpen] = useState(false);
-  
+
+  // "Start over" confirmation dialog (guards the destructive reset)
+  const [isStartOverConfirmOpen, setIsStartOverConfirmOpen] = useState(false);
+
+  // True while the bulk upload is actively running. Used to block the top-left
+  // "Back" control so the user can't navigate away mid-upload.
+  const [isUploadBusy, setIsUploadBusy] = useState(false);
+
+  // Refs read by the global popstate/beforeunload handlers (bound once on mount),
+  // so they always see the latest values without re-binding the listeners.
+  const currentStepRef = useRef(currentStep);
+  currentStepRef.current = currentStep;
+  const isUploadBusyRef = useRef(isUploadBusy);
+  isUploadBusyRef.current = isUploadBusy;
+  const handlePreviousStepRef = useRef<() => void>(() => {});
+  const historyTrapArmedRef = useRef(false);
+
   // Planday API integration - centralized hook usage
   const plandayApi = usePlandayApi();
   const { departments, employeeGroups, employeeTypes } = plandayApi;
@@ -118,6 +134,61 @@ export function WorkflowApp({ onStepChange }: WorkflowAppProps = {}) {
     }
   }, [currentStep, onStepChange]);
 
+  // Arm a single history "trap" entry when the user enters the workflow (leaves
+  // Authentication). The 7 steps are React state, not routes, so without this the
+  // browser back button would leave the SPA entirely and silently destroy an
+  // in-progress upload. With the trap in place, back fires popstate (handled
+  // below) instead of unloading the app.
+  useEffect(() => {
+    if (currentStep !== WorkflowStep.Authentication && !historyTrapArmedRef.current) {
+      window.history.pushState({ workflowTrap: true }, '');
+      historyTrapArmedRef.current = true;
+    } else if (currentStep === WorkflowStep.Authentication) {
+      historyTrapArmedRef.current = false;
+    }
+  }, [currentStep]);
+
+  // Map the browser back button to a single workflow step-back, and warn before
+  // a tab close / reload that would lose an in-progress upload. Bound once.
+  useEffect(() => {
+    const onPopState = () => {
+      const step = currentStepRef.current;
+      if (step === WorkflowStep.Authentication) {
+        // On step 1 there's nothing to go back to within the workflow; let the
+        // browser navigate away normally.
+        return;
+      }
+      // While an upload is actively running, swallow the back press entirely
+      // (re-arm the trap, don't navigate) so we never abandon a run mid-flight.
+      if (isUploadBusyRef.current) {
+        window.history.pushState({ workflowTrap: true }, '');
+        return;
+      }
+      // Re-arm the trap so the next back press is caught too — unless this press
+      // returns the user to Authentication (FileUpload is the last trapped step).
+      if (step !== WorkflowStep.FileUpload) {
+        window.history.pushState({ workflowTrap: true }, '');
+      } else {
+        historyTrapArmedRef.current = false;
+      }
+      handlePreviousStepRef.current();
+    };
+
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (currentStepRef.current !== WorkflowStep.Authentication) {
+        event.preventDefault();
+        event.returnValue = '';
+      }
+    };
+
+    window.addEventListener('popstate', onPopState);
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => {
+      window.removeEventListener('popstate', onPopState);
+      window.removeEventListener('beforeunload', onBeforeUnload);
+    };
+  }, []);
+
   /**
    * Move to the next step in the workflow
    */
@@ -128,7 +199,7 @@ export function WorkflowApp({ onStepChange }: WorkflowAppProps = {}) {
     if (currentIndex < mainSteps.length - 1) {
       // Mark current step as completed
       setCompletedSteps(prev => [...prev, currentStep]);
-      
+
       // Move to next main step
       setCurrentStep(mainSteps[currentIndex + 1]);
     }
@@ -228,11 +299,63 @@ export function WorkflowApp({ onStepChange }: WorkflowAppProps = {}) {
     }
   };
 
+  /**
+   * Go back exactly one step in the workflow (non-destructive). Powers the
+   * top-left "← Back" control and the browser back button. Each branch mirrors
+   * the per-step back transition (target step + completedSteps reset) that
+   * previously lived inline on each step component's back button.
+   *
+   * The Results step is special: its literal previous step (BulkUpload) re-runs
+   * the upload on mount, which would create duplicates. So "back" from Results
+   * routes through the safe edit-table round-trip, which strips already-created
+   * rows before returning to the validation/correction table.
+   */
+  const handlePreviousStep = () => {
+    switch (currentStep) {
+      case WorkflowStep.FileUpload:
+        setCurrentStep(WorkflowStep.Authentication);
+        setCompletedSteps([]);
+        break;
+      case WorkflowStep.ColumnMapping:
+        setCurrentStep(WorkflowStep.FileUpload);
+        setCompletedSteps([WorkflowStep.Authentication]);
+        break;
+      case WorkflowStep.ValidationCorrection:
+        // Returning to mapping resets the bulk-correction round-trip notice
+        setRoundTripNotice(null);
+        setCurrentStep(WorkflowStep.ColumnMapping);
+        setCompletedSteps([WorkflowStep.Authentication, WorkflowStep.FileUpload]);
+        break;
+      case WorkflowStep.FinalPreview:
+        setCurrentStep(WorkflowStep.ValidationCorrection);
+        setCompletedSteps([WorkflowStep.Authentication, WorkflowStep.FileUpload, WorkflowStep.ColumnMapping]);
+        break;
+      case WorkflowStep.BulkUpload:
+        // Safe: FinalPreview is a static review and never auto-uploads.
+        setCurrentStep(WorkflowStep.FinalPreview);
+        setCompletedSteps([WorkflowStep.Authentication, WorkflowStep.FileUpload, WorkflowStep.ColumnMapping, WorkflowStep.ValidationCorrection]);
+        break;
+      case WorkflowStep.Results:
+        // Safe round-trip: strips already-created rows so a re-run can't duplicate them.
+        handleBackToEditTable(uploadResults);
+        break;
+      default:
+        // Authentication (or any unknown step) has nowhere to go back to.
+        break;
+    }
+  };
+  handlePreviousStepRef.current = handlePreviousStep;
+
   // Determine if we should show the main header (only on step 1)
   const showMainHeader = currentStep === WorkflowStep.Authentication;
-  
-  // Determine if we should show the cancel button (steps 2-7)
-  const showCancelButton = currentStep !== WorkflowStep.Authentication;
+
+  // Determine if we should show the top navigation bar (steps 2-7)
+  const showTopNav = currentStep !== WorkflowStep.Authentication;
+
+  // The Results step is terminal: its only purpose-built backward action is the
+  // safe "Go back to edit table" button it renders itself, so we don't show a
+  // generic top-left "Back one step" there.
+  const showBackButton = showTopNav && currentStep !== WorkflowStep.Results;
 
   return (
     <>
@@ -259,16 +382,30 @@ export function WorkflowApp({ onStepChange }: WorkflowAppProps = {}) {
         />
       </div>
 
-      {/* Cancel Button - Shown on all steps except step 1 */}
-      {showCancelButton && (
-        <div className="mb-6 transition-all duration-500">
-          <Button
-            variant="outline"
-            onClick={handleCancelUpload}
-            className="text-red-600 border-red-300 hover:bg-red-50 hover:border-red-400"
+      {/* Top navigation - Shown on all steps except step 1.
+          Left: non-destructive "Back one step" (where users instinctively look).
+          Right: demoted, confirmation-guarded "Start over" (the destructive reset). */}
+      {showTopNav && (
+        <div className="mb-6 flex items-center justify-between transition-all duration-500">
+          {showBackButton ? (
+            <Button
+              variant="outline"
+              onClick={handlePreviousStep}
+              disabled={isUploadBusy}
+              title={isUploadBusy ? 'Please wait for the current upload to finish' : undefined}
+            >
+              ← Back one step
+            </Button>
+          ) : (
+            <span />
+          )}
+
+          <button
+            onClick={() => setIsStartOverConfirmOpen(true)}
+            className="text-sm text-gray-500 hover:text-red-600 underline transition-colors"
           >
-            ← Cancel upload and start over
-          </Button>
+            Start over
+          </button>
         </div>
       )}
 
@@ -425,10 +562,6 @@ export function WorkflowApp({ onStepChange }: WorkflowAppProps = {}) {
       {currentStep === WorkflowStep.FinalPreview && employees.length > 0 && (
         <FinalPreviewStep
           employees={employees}
-          onBack={() => {
-            setCurrentStep(WorkflowStep.ValidationCorrection);
-            setCompletedSteps([WorkflowStep.Authentication, WorkflowStep.FileUpload, WorkflowStep.ColumnMapping]);
-          }}
           onStartUpload={() => {
             handleNextStep(); // Go to bulk upload step
           }}
@@ -449,11 +582,8 @@ export function WorkflowApp({ onStepChange }: WorkflowAppProps = {}) {
             }
             handleNextStep(); // Go to results verification step
           }}
-          onBack={() => {
-            setCurrentStep(WorkflowStep.FinalPreview);
-            setCompletedSteps([WorkflowStep.Authentication, WorkflowStep.FileUpload, WorkflowStep.ColumnMapping, WorkflowStep.ValidationCorrection]);
-          }}
           onBackToEditTable={handleBackToEditTable}
+          onBusyChange={setIsUploadBusy}
         />
       )}
 
@@ -478,16 +608,6 @@ export function WorkflowApp({ onStepChange }: WorkflowAppProps = {}) {
             setOriginalEmployees([]);
             setPostCreationResults({});
             setExcludedEmployees([]);
-          }}
-          onBack={() => {
-            setCurrentStep(WorkflowStep.BulkUpload);
-            setCompletedSteps([
-              WorkflowStep.Authentication,
-              WorkflowStep.FileUpload,
-              WorkflowStep.ColumnMapping,
-              WorkflowStep.ValidationCorrection,
-              WorkflowStep.FinalPreview
-            ]);
           }}
           onReset={() => {
             // Complete reset of the entire application state
@@ -674,6 +794,27 @@ export function WorkflowApp({ onStepChange }: WorkflowAppProps = {}) {
       <VersionModal
         isOpen={isVersionModalOpen}
         onClose={() => setIsVersionModalOpen(false)}
+      />
+
+      {/* Start-over confirmation - guards the destructive reset */}
+      <ConfirmDialog
+        isOpen={isStartOverConfirmOpen}
+        title="Start over?"
+        message={
+          <>
+            This clears all uploaded data, mappings, and corrections, and logs you out
+            of Planday. You'll have to authenticate and re-upload from scratch.
+            This can't be undone.
+          </>
+        }
+        confirmLabel="Yes, start over"
+        cancelLabel="Keep my progress"
+        confirmVariant="error"
+        onConfirm={() => {
+          setIsStartOverConfirmOpen(false);
+          handleCancelUpload();
+        }}
+        onCancel={() => setIsStartOverConfirmOpen(false)}
       />
     </>
   );

--- a/src/components/results/BulkUploadStep.tsx
+++ b/src/components/results/BulkUploadStep.tsx
@@ -18,13 +18,14 @@ export interface PostCreationResults {
 interface BulkUploadStepProps {
   employees: Employee[];
   onComplete: (results: EmployeeUploadResult[], postCreationResults?: PostCreationResults) => void;
-  onBack: () => void;
   /**
    * Return to the validation/correction (edit) table with the uploaded data still in memory.
    * Rows that were created in Planday (success + partial) are stripped before re-entry so a
    * re-run can't duplicate them; failed rows remain for correction and retry.
    */
   onBackToEditTable: (results: EmployeeUploadResult[]) => void;
+  /** Reports whether an upload is actively running, so the parent can block top-level navigation. */
+  onBusyChange?: (busy: boolean) => void;
   className?: string;
 }
 
@@ -40,8 +41,8 @@ interface BulkUploadStepProps {
 const BulkUploadStep: React.FC<BulkUploadStepProps> = ({
   employees,
   onComplete,
-  onBack,
   onBackToEditTable,
+  onBusyChange,
   className = ''
 }) => {
   const [status, setStatus] = useState<'preparing' | 'validating' | 'authenticating' | 'uploading' | 'post-processing' | 'completed' | 'aborted' | 'error'>('preparing');
@@ -62,6 +63,18 @@ const BulkUploadStep: React.FC<BulkUploadStepProps> = ({
   const [showAbortConfirm, setShowAbortConfirm] = useState(false);
 
   const plandayApi = usePlandayApi();
+
+  // Report active-upload state upward so the parent can disable top-level "Back"
+  // while a run is in flight (mirrors the in-step back button's disabled states).
+  useEffect(() => {
+    const busy = status === 'validating' || status === 'authenticating' || status === 'uploading' || status === 'post-processing';
+    onBusyChange?.(busy);
+  }, [status, onBusyChange]);
+
+  // Clear the busy flag if this step unmounts mid-run.
+  useEffect(() => {
+    return () => onBusyChange?.(false);
+  }, [onBusyChange]);
 
   // Add log entry for progress tracking
   const addLogEntry = (message: string) => {
@@ -1111,20 +1124,8 @@ const BulkUploadStep: React.FC<BulkUploadStepProps> = ({
         </Card>
       )}
 
-      {/* Action Buttons */}
-      <div className="flex justify-between items-center pt-6">
-        <Button
-          variant="secondary"
-          onClick={onBack}
-          disabled={status === 'uploading' || status === 'validating' || status === 'authenticating' || status === 'post-processing'}
-          className="flex items-center space-x-2"
-        >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 19l-7-7 7-7" />
-          </svg>
-          <span>Back to Preview</span>
-        </Button>
-
+      {/* Action Buttons (step-back lives in the top navigation bar) */}
+      <div className="flex justify-end items-center pt-6">
         <div className="space-x-3">
           {/* Validation Error - Go back to the edit table to fix issues */}
           {status === 'error' && validationErrors.length > 0 && (

--- a/src/components/results/FinalPreviewStep.tsx
+++ b/src/components/results/FinalPreviewStep.tsx
@@ -5,7 +5,6 @@ import { mappingService, ValidationService, MappingUtils } from '../../services/
 
 interface FinalPreviewStepProps {
   employees: Employee[];
-  onBack: () => void;
   onStartUpload: () => void;
 }
 
@@ -21,7 +20,6 @@ interface FinalPreviewStepProps {
  */
 const FinalPreviewStep: React.FC<FinalPreviewStepProps> = ({
   employees,
-  onBack,
   onStartUpload
 }) => {
   const [convertedEmployee, setConvertedEmployee] = useState<any>(null);
@@ -531,19 +529,8 @@ const FinalPreviewStep: React.FC<FinalPreviewStepProps> = ({
         </div>
       </Card>
 
-      {/* Action Buttons */}
-      <div className="flex flex-col sm:flex-row justify-between items-center gap-4 pt-6">
-        <Button
-          variant="secondary"
-          onClick={onBack}
-          className="flex items-center space-x-2 w-full sm:w-auto"
-        >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 19l-7-7 7-7" />
-          </svg>
-          <span>Back to Validation</span>
-        </Button>
-
+      {/* Action Buttons (step-back lives in the top navigation bar) */}
+      <div className="flex flex-col sm:flex-row justify-end items-center gap-4 pt-6">
         <Button
           variant="primary"
           onClick={onStartUpload}

--- a/src/components/results/ResultsVerificationStep.tsx
+++ b/src/components/results/ResultsVerificationStep.tsx
@@ -23,7 +23,6 @@ interface ResultsVerificationStepProps {
   postCreationResults?: PostCreationResults;
   excludedEmployees?: ExcludedEmployee[];
   onComplete: () => void;
-  onBack: () => void;
   onReset?: () => void; // New prop for resetting the entire process
   onBackToEditTable?: () => void; // Return to the edit table, stripping already-created rows
   className?: string;
@@ -60,7 +59,6 @@ const ResultsVerificationStep: React.FC<ResultsVerificationStepProps> = ({
   postCreationResults,
   excludedEmployees = [],
   onComplete,
-  onBack,
   onReset,
   onBackToEditTable,
   className = ''
@@ -759,12 +757,8 @@ const ResultsVerificationStep: React.FC<ResultsVerificationStepProps> = ({
         </Card>
       )}
 
-      {/* Actions */}
-      <div className="flex justify-between items-center pt-6">
-        <Button variant="outline" onClick={onBack}>
-          Back to Upload
-        </Button>
-        
+      {/* Actions (step-back lives in the top navigation bar) */}
+      <div className="flex justify-end items-center pt-6">
         <div className="flex space-x-3">
           {onBackToEditTable && (
             <Button onClick={onBackToEditTable} variant="outline">

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,75 @@
+/**
+ * Generic Confirmation Dialog
+ * Used to guard destructive actions (e.g. "start over", which wipes all
+ * in-progress upload state and logs the user out) behind an explicit confirm.
+ */
+
+import React, { useEffect } from 'react';
+import { Button } from './Button';
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  title: string;
+  message: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  confirmVariant?: 'primary' | 'error';
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  isOpen,
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  confirmVariant = 'error',
+  onConfirm,
+  onCancel,
+}) => {
+  useEffect(() => {
+    const handleEscKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onCancel();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscKey);
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscKey);
+    };
+  }, [isOpen, onCancel]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black bg-opacity-50"
+        onClick={onCancel}
+      />
+
+      {/* Modal */}
+      <div className="relative bg-white rounded-lg shadow-xl max-w-md w-full mx-4">
+        <div className="p-6">
+          <h2 className="text-xl font-semibold text-gray-900 mb-3">{title}</h2>
+          <div className="text-sm text-gray-600 mb-6">{message}</div>
+
+          <div className="flex justify-end gap-3">
+            <Button variant="secondary" onClick={onCancel}>
+              {cancelLabel}
+            </Button>
+            <Button variant={confirmVariant} onClick={onConfirm}>
+              {confirmLabel}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -15,6 +15,7 @@ export { TermsOfServiceModal } from './TermsOfServiceModal';
 export { VersionModal, getCurrentVersion } from './VersionModal';
 export { FieldDefinitionsModal, FieldDefinitionsDebugButton } from './FieldDefinitionsModal';
 export { FieldSelectionModal } from './FieldSelectionModal';
+export { ConfirmDialog } from './ConfirmDialog';
 // DateFormatModal replaced with DateFormatSelectionStep (normal page instead of modal)
 
 // Beta Components

--- a/src/components/upload/FileUploadStep.tsx
+++ b/src/components/upload/FileUploadStep.tsx
@@ -38,7 +38,6 @@ interface FileUploadStepProps extends StepComponentProps {
 
 export const FileUploadStep: React.FC<FileUploadStepProps> = ({
   onNext,
-  onPrevious,
   onFileProcessed,
   isLoading = false,
   isAuthenticated = false,
@@ -607,16 +606,8 @@ export const FileUploadStep: React.FC<FileUploadStepProps> = ({
         renderResults()
       )}
 
-      {/* Action Buttons */}
-      <div className="flex justify-between">
-        <Button
-          variant="secondary"
-          onClick={onPrevious}
-          disabled={isLoading || isProcessing}
-        >
-          ← Back to Authentication
-        </Button>
-        
+      {/* Action Buttons (step-back lives in the top navigation bar) */}
+      <div className="flex justify-end">
         <Button
           onClick={onNext}
           disabled={isLoading || isProcessing || !parseResult?.data}


### PR DESCRIPTION
Closes #36.

## Summary

- **Top-left "← Back one step"**: relocated the per-step back action to the top of the page (steps 2–7), centralized in a new `handlePreviousStep()`. Column Mapping (step 3) can now go back to File Upload — the previously-missing case.
- **Demoted "Start over"**: the destructive cancel-and-reset is now a subtle top-right link, gated behind a confirmation dialog (new `ConfirmDialog` UI component) before it wipes state and logs out.
- **Browser back / tab close no longer silently destroys an in-progress upload**: a history "trap" maps browser-back to a single workflow step-back, and a `beforeunload` guard warns before reload/close mid-flow.
- Removed the now-redundant bottom back buttons from the four linear steps (FileUpload, FinalPreview, BulkUpload, Results).

## Safety guards

`BulkUploadStep` auto-starts the upload on mount, so navigating *into* it would create duplicate rows. Therefore:
- Back is disabled while an upload is actively running (via a new `onBusyChange` callback), and browser-back is swallowed mid-run.
- "Back" from the Results step routes through the **safe edit-table round-trip** (which strips already-created rows) instead of literally re-entering the upload step. The Results "Back to Upload" button (the same footgun) was removed.

## Deliberate judgment call

The multi-phase validation/correction flow keeps its own in-context `← Back to Mapping` buttons. The issue explicitly warned against breaking its sub-step navigation, and removing them would cascade through several complex files. The top "Back one step" goes to the same place, so behavior stays consistent — there's just a second back affordance on that one screen. Easy to fully deduplicate in a follow-up if preferred.

## Test plan

- [ ] On steps 2–7, confirm "← Back one step" appears top-left and moves back exactly one step (incl. Mapping → Upload).
- [ ] "Start over" link shows a confirmation dialog; confirming clears all state + logs out; cancelling preserves progress.
- [ ] Browser back button steps back one workflow step instead of leaving the app; reaching Authentication then allows leaving.
- [ ] Tab close / reload mid-flow shows the browser's "leave site?" warning.
- [ ] During an active bulk upload, "Back" is disabled and browser-back does not abandon the run.
- [ ] "Back" from Results returns to the edit table with already-created rows stripped (no duplicate risk).
- [ ] Validation/correction multi-phase flow still navigates correctly.

https://claude.ai/code/session_01AohZ8XYFomA7NDoXk7wYyn

---
_Generated by [Claude Code](https://claude.ai/code/session_01AohZ8XYFomA7NDoXk7wYyn)_