### PR TITLE
Add resync button to refresh portal options without restarting upload

### DIFF
--- a/src/components/WorkflowApp.tsx
+++ b/src/components/WorkflowApp.tsx
@@ -84,6 +84,36 @@ export function WorkflowApp({ onStepChange }: WorkflowAppProps = {}) {
   const plandayApi = usePlandayApi();
   const { departments, employeeGroups, employeeTypes } = plandayApi;
 
+  // Resync state - lets the user pull fresh portal options (departments, groups, types,
+  // supervisors, enum fields, ...) mid-flow after creating a missing option in Planday,
+  // then re-validate the rows without restarting from authentication. The nonce is bumped
+  // on every successful resync and threaded into the validation step to force a fresh
+  // validation pass against the newly-loaded options (entered cell values are preserved).
+  const [isResyncing, setIsResyncing] = useState(false);
+  const [resyncNonce, setResyncNonce] = useState(0);
+  const [resyncError, setResyncError] = useState<string | null>(null);
+  const [resyncJustSucceeded, setResyncJustSucceeded] = useState(false);
+
+  const handleResync = async () => {
+    if (isResyncing) return;
+    setIsResyncing(true);
+    setResyncError(null);
+    setResyncJustSucceeded(false);
+    try {
+      await plandayApi.resyncPortalData();
+      setResyncNonce(prev => prev + 1);
+      setResyncJustSucceeded(true);
+      setTimeout(() => setResyncJustSucceeded(false), 4000);
+    } catch (error) {
+      console.error('❌ Resync failed:', error);
+      setResyncError(
+        error instanceof Error ? error.message : 'Failed to resync portal data. Please try again.'
+      );
+    } finally {
+      setIsResyncing(false);
+    }
+  };
+
   // Security: Clean up any stray tokens from localStorage on app initialization
   useEffect(() => {
     // Our app uses sessionStorage for security, but clean localStorage
@@ -234,6 +264,9 @@ export function WorkflowApp({ onStepChange }: WorkflowAppProps = {}) {
   // Determine if we should show the cancel button (steps 2-7)
   const showCancelButton = currentStep !== WorkflowStep.Authentication;
 
+  // The resync control is only relevant while validating/correcting against portal options
+  const showResyncButton = currentStep === WorkflowStep.ValidationCorrection;
+
   return (
     <>
       {/* App Header - Only shown on step 1, slides up and disappears on step 2+ */}
@@ -259,9 +292,27 @@ export function WorkflowApp({ onStepChange }: WorkflowAppProps = {}) {
         />
       </div>
 
-      {/* Cancel Button - Shown on all steps except step 1 */}
+      {/* Top-left controls - Shown on all steps except step 1 */}
       {showCancelButton && (
-        <div className="mb-6 transition-all duration-500">
+        <div className="mb-6 transition-all duration-500 flex flex-wrap items-center gap-3">
+          {showResyncButton && (
+            <Button
+              variant="outline"
+              onClick={handleResync}
+              disabled={isResyncing}
+              title="Re-fetch departments, employee groups, employee types, supervisors and other field options from Planday, then re-validate the rows. Your entered corrections are kept."
+              className="text-blue-600 border-blue-300 hover:bg-blue-50 hover:border-blue-400 disabled:opacity-60"
+            >
+              {isResyncing ? (
+                <span className="flex items-center gap-2">
+                  <span className="inline-block animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600"></span>
+                  Resyncing…
+                </span>
+              ) : (
+                '⟳ Resync portal data'
+              )}
+            </Button>
+          )}
           <Button
             variant="outline"
             onClick={handleCancelUpload}
@@ -269,6 +320,12 @@ export function WorkflowApp({ onStepChange }: WorkflowAppProps = {}) {
           >
             ← Cancel upload and start over
           </Button>
+          {showResyncButton && resyncJustSucceeded && (
+            <span className="text-sm text-green-700">✓ Portal data refreshed</span>
+          )}
+          {showResyncButton && resyncError && (
+            <span className="text-sm text-red-700">{resyncError}</span>
+          )}
         </div>
       )}
 
@@ -388,6 +445,7 @@ export function WorkflowApp({ onStepChange }: WorkflowAppProps = {}) {
               departments={departments}
               employeeGroups={employeeGroups}
               employeeTypes={employeeTypes}
+              resyncNonce={resyncNonce}
               resolvedPatterns={resolvedBulkCorrectionPatterns}
               onPatternsResolved={(patterns) => {
                 setResolvedBulkCorrectionPatterns(patterns);

--- a/src/components/validation/DataCorrectionStep.tsx
+++ b/src/components/validation/DataCorrectionStep.tsx
@@ -34,6 +34,7 @@ interface DataCorrectionStepProps {
   employeeGroups: PlandayEmployeeGroup[];
   employeeTypes: PlandayEmployeeType[];
   plandayApi: UsePlandayApiReturn;
+  resyncNonce?: number;
   onComplete: (correctedEmployees: Employee[], excludedEmployees?: ExcludedEmployee[]) => void;
   onBack: () => void;
   className?: string;
@@ -56,6 +57,7 @@ export const DataCorrectionStep: React.FC<DataCorrectionStepProps> = ({
   employeeGroups,
   employeeTypes,
   plandayApi,
+  resyncNonce,
   onComplete,
   onBack,
   className = ''
@@ -141,13 +143,16 @@ export const DataCorrectionStep: React.FC<DataCorrectionStepProps> = ({
     }
   }, [employees.length]); // Only run when employees change, not on every re-render
 
-  // Validate all employees on component mount and when data changes
+  // Validate all employees on component mount and when data changes.
+  // resyncNonce is included so a portal-data resync (which repopulates the validation
+  // caches without changing the employee rows) forces a fresh validation pass — newly
+  // created portal options then clear their "not found in Planday" errors.
   useEffect(() => {
     // Re-running validation due to data changes
     validateAllEmployees().catch(error => {
       console.error('❌ Validation failed:', error);
     });
-  }, [employees, existingEmployees, existingSsnEmployees]); // Re-validate when existing employees data changes
+  }, [employees, existingEmployees, existingSsnEmployees, resyncNonce]); // Re-validate when existing employees data changes or after a resync
 
   // Focus input when editing cell (only on initial edit start)
   useEffect(() => {

--- a/src/components/validation/ValidationAndCorrectionStep.tsx
+++ b/src/components/validation/ValidationAndCorrectionStep.tsx
@@ -23,6 +23,7 @@ interface ValidationAndCorrectionStepProps {
   onComplete: (correctedEmployees: any[], excludedEmployees?: ExcludedEmployee[]) => void;
   onBack: () => void;
   plandayApi: UsePlandayApiReturn;
+  resyncNonce?: number;
   className?: string;
 }
 
@@ -33,10 +34,11 @@ const DataCorrectionStepWithPreprocessing: React.FC<{
   employeeGroups: any[];
   employeeTypes: any[];
   plandayApi: UsePlandayApiReturn;
+  resyncNonce?: number;
   onComplete: (correctedEmployees: any[], excludedEmployees?: ExcludedEmployee[]) => void;
   onBack: () => void;
   className?: string;
-}> = ({ employees, departments, employeeGroups, employeeTypes, plandayApi, onComplete, onBack, className }) => {
+}> = ({ employees, departments, employeeGroups, employeeTypes, plandayApi, resyncNonce, onComplete, onBack, className }) => {
   const [preprocessedEmployees, setPreprocessedEmployees] = useState<any[]>([]);
   const [isPreprocessing, setIsPreprocessing] = useState(true);
 
@@ -85,7 +87,13 @@ const DataCorrectionStepWithPreprocessing: React.FC<{
       setPreprocessedEmployees(employees);
       setIsPreprocessing(false);
     }
-  }, [employees, departments, employeeGroups, employeeTypes]);
+    // Intentionally depends only on `employees`. A portal-data resync changes the
+    // departments/groups/types references, but re-preprocessing here would unmount
+    // DataCorrectionStep and rebuild it from the pre-edit baseline, discarding the
+    // user's in-progress cell edits. Resync re-validation is handled inside
+    // DataCorrectionStep via resyncNonce instead, which preserves entered values.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [employees]);
 
   if (isPreprocessing) {
     return (
@@ -107,6 +115,7 @@ const DataCorrectionStepWithPreprocessing: React.FC<{
       employeeGroups={employeeGroups}
       employeeTypes={employeeTypes}
       plandayApi={plandayApi}
+      resyncNonce={resyncNonce}
       onComplete={onComplete}
       onBack={onBack}
       className={className}
@@ -389,6 +398,7 @@ const ValidationAndCorrectionStep: React.FC<ValidationAndCorrectionStepProps> = 
   onComplete,
   onBack,
   plandayApi,
+  resyncNonce,
   className = ''
 }) => {
   const [currentPhase, setCurrentPhase] = useState<'bulk-correction' | 'date-format-selection' | 'individual-correction' | 'complete'>('bulk-correction');
@@ -842,6 +852,7 @@ const ValidationAndCorrectionStep: React.FC<ValidationAndCorrectionStepProps> = 
         employeeGroups={employeeGroups}
         employeeTypes={employeeTypes}
         plandayApi={plandayApi}
+        resyncNonce={resyncNonce}
         onComplete={(correctedEmployees, excludedEmployees) => {
           setCurrentEmployees(correctedEmployees);
           // Individual corrections completed

--- a/src/hooks/usePlandayApi.ts
+++ b/src/hooks/usePlandayApi.ts
@@ -105,6 +105,7 @@ interface PlandayApiActions {
   refreshFieldDefinitions: () => Promise<void>;
   refreshPortalInfo: () => Promise<void>;
   refreshPlandayData: () => Promise<void>;
+  resyncPortalData: () => Promise<void>;
   
   // Upload actions
   uploadEmployees: (
@@ -778,6 +779,91 @@ export const usePlandayApi = (): UsePlandayApiReturn => {
   }, [state.isAuthenticated, refreshDepartments, refreshEmployeeGroups, refreshEmployeeTypes, refreshSupervisors, refreshSkills, refreshFieldDefinitions, refreshPortalInfo]);
 
   /**
+   * Resync all portal option data (departments, employee groups, employee types,
+   * supervisors, skills, salary types, contract rules, field definitions) in a single
+   * pass and re-initialize every cache layer at once.
+   *
+   * Unlike refreshPlandayData (which runs the per-field refreshers in parallel, each
+   * re-initializing MappingUtils from a partially-stale state snapshot), this fetches
+   * everything first and then re-initializes the services once with the complete, fresh
+   * dataset — mirroring the initial load in authenticate(). This avoids the partial-refresh
+   * trap where a newly-created portal option is missed because one cache layer kept old data.
+   *
+   * It refreshes only the portal's option lists — it never touches the user's mapped or
+   * corrected employee rows.
+   */
+  const resyncPortalData = useCallback(async (): Promise<void> => {
+    if (!PlandayApi.isAuthenticated()) {
+      throw new Error('Not authenticated');
+    }
+
+    // Helper for optional fetches that return empty array on failure (e.g., CORS issues)
+    const fetchOptional = async <T>(
+      fetchFn: () => Promise<T[]>,
+      name: string
+    ): Promise<T[]> => {
+      try {
+        return await fetchFn();
+      } catch (error) {
+        console.warn(`⚠️ Could not fetch ${name}, feature will be unavailable:`, error);
+        return [];
+      }
+    };
+
+    // Fetch everything in parallel before touching any cache
+    const [departments, employeeGroups, employeeTypes, supervisors, skills, salaryTypes, contractRules, fieldDefinitions, employeeSample] = await Promise.all([
+      PlandayApi.getDepartments(),
+      PlandayApi.getEmployeeGroups(),
+      PlandayApi.getEmployeeTypes(),
+      PlandayApi.getSupervisors(),
+      PlandayApi.getSkills(),
+      PlandayApi.getSalaryTypes(),
+      fetchOptional(() => PlandayApi.getContractRules(), 'contract rules'),
+      PlandayApi.getFieldDefinitions(),
+      PlandayApi.fetchEmployeeSample(5)
+    ]);
+
+    // Discover and merge fields from employee sample before initializing services
+    if (employeeSample.length > 0) {
+      const discoveredFields = discoverFieldsFromEmployees(employeeSample);
+      mergeDiscoveredFields(fieldDefinitions, discoveredFields);
+    }
+
+    // Re-initialize all cache layers once with the complete fresh dataset
+    MappingUtils.initialize(departments, employeeGroups, employeeTypes);
+    MappingUtils.setSupervisors(supervisors);
+    MappingUtils.setSkills(skills);
+    MappingUtils.setSalaryTypes(salaryTypes);
+    MappingUtils.setContractRules(contractRules);
+    ValidationService.initialize(fieldDefinitions);
+    FieldDefinitionValidator.initialize(fieldDefinitions);
+
+    // Refresh portal info / phone parser country (non-critical)
+    try {
+      const portalInfo = await PlandayApi.getPortalInfo();
+      const { PhoneParser } = await import('../utils');
+      PhoneParser.setPortalCountry(portalInfo.country);
+      updateState({ portalInfo });
+    } catch (error) {
+      console.warn('⚠️ Could not refresh portal info during resync:', error);
+    }
+
+    // Push fresh data into hook state (new array references trigger downstream re-validation)
+    updateState({
+      departments,
+      employeeGroups,
+      employeeTypes,
+      supervisors,
+      skills,
+      salaryTypes,
+      contractRules,
+      fieldDefinitions,
+    });
+
+    console.log('✅ Portal data resynced and all caches re-initialized');
+  }, [updateState]);
+
+  /**
    * Upload employees to Planday
    */
   const uploadEmployees = useCallback(async (
@@ -1302,6 +1388,7 @@ export const usePlandayApi = (): UsePlandayApiReturn => {
     refreshFieldDefinitions,
     refreshPortalInfo,
     refreshPlandayData,
+    resyncPortalData,
     uploadEmployees,
     atomicUploadEmployees,
     fetchEmployees,


### PR DESCRIPTION
## Summary

Implements #39 — a one-click **resync** that refreshes all portal option lists (departments, employee groups, employee types, supervisors, skills, field/enum definitions) mid-flow and re-validates the rows, so an option created in Planday is recognized without restarting from Authentication.

### Root cause
Portal options were fetched once at auth and cached across three layers that were never invalidated during validation/correction:
- hook state in `usePlandayApi.ts`
- the lookup maps in `MappingService`
- the static caches on `ValidationService` / `FieldDefinitionValidator`

Re-validation checked those stale copies, so a newly-created option stayed "not found in Planday". The pre-existing `refreshPlandayData()` also had a partial-refresh trap: its parallel per-field `MappingUtils.initialize()` calls each re-init from a stale state snapshot, so the last to finish could clobber fresh data with old.

### Changes
- **`usePlandayApi.ts`** — new `resyncPortalData()` that fetches everything in parallel, then re-initializes **all** cache layers once with the complete dataset (mirrors the auth load, avoids the staleness trap). Refreshes only portal options, never employee rows.
- **`WorkflowApp.tsx`** — top-left "⟳ Resync portal data" button on the Validate/Correct step with loading/success/error states, plus a `resyncNonce` bumped on success.
- **`ValidationAndCorrectionStep.tsx`** — threads `resyncNonce` through; scopes the preprocessing effect to `[employees]` so a portal-data refresh no longer unmounts the correction table (which would discard in-progress edits).
- **`DataCorrectionStep.tsx`** — adds `resyncNonce` to the validation effect deps to force a fresh validation pass against the new caches.

### How it satisfies the issue's constraints
- **Client-side only** — refresh is just re-calling the Planday API from the browser.
- **Respects rate limits / 429** — reuses the existing API client's handling.
- **Entered cell values preserved** — `DataCorrectionStep` keeps its local edit state and no longer remounts on resync; resync only re-validates.
- **All cache layers repopulated** — hook state, `MappingService` maps, and both static validator caches are re-initialized together.
- **Per-row flow intact** — bulk phase re-detects via the refreshed arrays; individual phase re-validates via `resyncNonce`.

## Test plan
- [ ] `npm run build` passes (tsc + vite) — verified locally
- [ ] `npm run lint` — 0 errors (pre-existing warnings only) — verified locally
- [ ] Manual: in a live portal, reach Validate/Correct with a row whose department/group/type doesn't exist; create it in Planday; click Resync; confirm the correction card clears and entered cell values are untouched
- [ ] Manual: same for a custom enum field option in the individual-correction table
- [ ] Manual: confirm in-progress cell edits survive a resync

Closes #39

https://claude.ai/code/session_01VM3veg6fYJ71NT8RETLg9f

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM3veg6fYJ71NT8RETLg9f)_